### PR TITLE
fix: typos in documentation files

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Automata DCAP Attestation contract implements two attestation methods available 
 
 |  | On-Chain | Groth16 Proof Verification with RiscZero | Groth16 Proof Verification with SP1 V3 | Plonk Proof Verification with SP1 V3| 
 | --- | --- | --- | --- | --- |
-| Quote Verification Time | Instant | Proving takes 2 - 5 minutes, instant verification | Proving takes <2 minutes, instant verification  | Proving takes <2 minutes, instant verification |
+| Quote Verification Time | Instant | Proving takes 2–5 minutes, with instant verification | Proving takes <2 minutes, instant verification  | Proving takes <2 minutes, instant verification |
 | Gas Cost | ~4-5M gas (varies by collateral size) | 351k gas | 325k gas | 410k gas |
 | Execution | Runs fully on-chain | Execution proven by remote prover Bonsai | Execution proven by the SP1 Network | Execution proven by the SP1 Network |
 


### PR DESCRIPTION
Corrected ` Proving takes 2 - 5 minutes, instant verification` to `Proving takes 2–5 minutes, with instant verification`