### PR TITLE
[TOB] DEV-3794: Expiry Check on collateral reads via PCCSRouter

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,4 +10,4 @@
 [submodule "lib/automata-on-chain-pccs"]
 	path = lib/automata-on-chain-pccs
 	url = https://github.com/automata-network/automata-on-chain-pccs
-	branch = main
+	branch = DEV-3794

--- a/contracts/PCCSRouter.sol
+++ b/contracts/PCCSRouter.sol
@@ -54,12 +54,20 @@ contract PCCSRouter is IPCCSRouter, Ownable {
 
     // a93fad2a
     error QEIdentityNotFound(EnclaveId id, uint256 quoteVersion);
+    // cb5a2635
+    error QEIdentityExpired(EnclaveId id, uint256 quoteVersion);
     // eb9cf5a3
     error FmspcTcbNotFound(TcbId id, uint256 tcbVersion);
+    // 2fff9f55
+    error FmspcTcbExpired(TcbId id, uint256 tcbVersion);
     // da236293
     error CertNotFound(CA ca);
+    // 52a1f316
+    error CertExpired(CA ca);
     // 18c6f762
     error CrlNotFound(CA ca);
+    // a5b5088a
+    error CrlExpired(CA ca);
     // ee90c468
     error Forbidden();
 
@@ -121,12 +129,16 @@ contract PCCSRouter is IPCCSRouter, Ownable {
     {
         EnclaveIdentityDao enclaveIdDao = EnclaveIdentityDao(qeIdDaoAddr);
         bytes32 key = enclaveIdDao.ENCLAVE_ID_KEY(uint256(id), quoteVersion);
-        bytes memory data = enclaveIdDao.getAttestedData(key);
-        valid = data.length > 0;
-        if (valid) {
-            (identity,,) = abi.decode(data, (IdentityObj, string, bytes));
+        if (_loadDataIfNotExpired(key, qeIdDaoAddr)) {
+            bytes memory data = enclaveIdDao.getAttestedData(key);
+            valid = data.length > 0;
+            if (valid) {
+                (identity,,) = abi.decode(data, (IdentityObj, string, bytes));
+            } else {
+                revert QEIdentityNotFound(id, quoteVersion);
+            }
         } else {
-            revert QEIdentityNotFound(id, quoteVersion);
+            revert QEIdentityExpired(id, quoteVersion);
         }
     }
 
@@ -139,15 +151,19 @@ contract PCCSRouter is IPCCSRouter, Ownable {
     {
         FmspcTcbDao tcbDao = FmspcTcbDao(fmspcTcbDaoAddr);
         bytes32 key = tcbDao.FMSPC_TCB_KEY(uint8(TcbId.SGX), fmspc, 2);
-        TcbInfoBasic memory tcbInfo;
-        bytes memory data = tcbDao.getAttestedData(key);
-        valid = data.length > 0;
-        if (valid) {
-            bytes memory encodedLevels;
-            (tcbInfo, encodedLevels,,) = abi.decode(data, (TcbInfoBasic, bytes, string, bytes));
-            tcbLevelsV2 = _decodeTcbLevels(encodedLevels);
+        if (_loadDataIfNotExpired(key, fmspcTcbDaoAddr)) {
+            TcbInfoBasic memory tcbInfo;
+            bytes memory data = tcbDao.getAttestedData(key);
+            valid = data.length > 0;
+            if (valid) {
+                bytes memory encodedLevels;
+                (tcbInfo, encodedLevels,,) = abi.decode(data, (TcbInfoBasic, bytes, string, bytes));
+                tcbLevelsV2 = _decodeTcbLevels(encodedLevels);
+            } else {
+                revert FmspcTcbNotFound(TcbId.SGX, 2);
+            }
         } else {
-            revert FmspcTcbNotFound(TcbId.SGX, 2);
+            revert FmspcTcbExpired(TcbId.SGX, 2);
         }
     }
 
@@ -165,20 +181,24 @@ contract PCCSRouter is IPCCSRouter, Ownable {
     {
         FmspcTcbDao tcbDao = FmspcTcbDao(fmspcTcbDaoAddr);
         bytes32 key = tcbDao.FMSPC_TCB_KEY(uint8(id), fmspc, 3);
-        TcbInfoBasic memory tcbInfo;
-        bytes memory data = tcbDao.getAttestedData(key);
-        valid = data.length > 0;
-        if (valid) {
-            bytes memory encodedLevels;
-            bytes memory encodedTdxModuleIdentities;
-            (tcbInfo, tdxModule, encodedTdxModuleIdentities, encodedLevels,,) =
-                abi.decode(data, (TcbInfoBasic, TDXModule, bytes, bytes, string, bytes));
-            tcbLevelsV3 = _decodeTcbLevels(encodedLevels);
-            if (encodedTdxModuleIdentities.length > 0) {
-                tdxModuleIdentities = _decodeTdxModuleIdentities(encodedTdxModuleIdentities);
+        if (_loadDataIfNotExpired(key, fmspcTcbDaoAddr)) {
+            TcbInfoBasic memory tcbInfo;
+            bytes memory data = tcbDao.getAttestedData(key);
+            valid = data.length > 0;
+            if (valid) {
+                bytes memory encodedLevels;
+                bytes memory encodedTdxModuleIdentities;
+                (tcbInfo, tdxModule, encodedTdxModuleIdentities, encodedLevels,,) =
+                    abi.decode(data, (TcbInfoBasic, TDXModule, bytes, bytes, string, bytes));
+                tcbLevelsV3 = _decodeTcbLevels(encodedLevels);
+                if (encodedTdxModuleIdentities.length > 0) {
+                    tdxModuleIdentities = _decodeTdxModuleIdentities(encodedTdxModuleIdentities);
+                }
+            } else {
+                revert FmspcTcbNotFound(id, 3);
             }
         } else {
-            revert FmspcTcbNotFound(id, 3);
+            revert FmspcTcbExpired(id, 3);
         }
     }
 
@@ -237,27 +257,47 @@ contract PCCSRouter is IPCCSRouter, Ownable {
 
     function _getPcsAttestationData(CA ca, bool crl) private view returns (bool valid, bytes memory ret) {
         PcsDao pcsDao = PcsDao(pcsDaoAddr);
-        ret = pcsDao.getAttestedData(pcsDao.PCS_KEY(ca, crl));
-        valid = ret.length > 0;
-        if (!valid) {
+        bytes32 key = pcsDao.PCS_KEY(ca, crl);
+        if (_loadDataIfNotExpired(key, pcsDaoAddr)) {
+            ret = pcsDao.getAttestedData(key);
+            valid = ret.length > 0;
+            if (!valid) {
+                if (crl) {
+                    revert CrlNotFound(ca);
+                } else {
+                    revert CertNotFound(ca);
+                }
+            }
+        } else {
             if (crl) {
-                revert CrlNotFound(ca);
+                revert CrlExpired(ca);
             } else {
-                revert CertNotFound(ca);
+                revert CertExpired(ca);
             }
         }
     }
 
     function _getPcsHash(CA ca, bool crl) private view returns (bool valid, bytes32 hash) {
         PcsDao pcsDao = PcsDao(pcsDaoAddr);
-        hash = pcsDao.getCollateralHash(pcsDao.PCS_KEY(ca, crl));
-        valid = hash != bytes32(0);
-        if (!valid) {
-            if (crl) {
-                revert CrlNotFound(ca);
-            } else {
-                revert CertNotFound(ca);
+        bytes32 key = pcsDao.PCS_KEY(ca, crl);
+        if (_loadDataIfNotExpired(key, pcsDaoAddr)) {
+             hash = pcsDao.getCollateralHash(key);
+            valid = hash != bytes32(0);
+            if (!valid) {
+                if (crl) {
+                    revert CrlNotFound(ca);
+                } else {
+                    revert CertNotFound(ca);
+                }
             }
         }
+    }
+
+    function _loadDataIfNotExpired(bytes32 key, address dao) private view returns (bool valid) {
+        bytes4 COLLATERAL_VALIDITY_SELECTOR = 0x3e960426;
+        (bool success, bytes memory ret) = dao.staticcall(abi.encodeWithSelector(COLLATERAL_VALIDITY_SELECTOR, key));
+        require(success, "Failed to determine collateral validity");
+        (uint64 issuedAt, uint64 expiredAt) = abi.decode(ret, (uint64, uint64));
+        valid = block.timestamp >= issuedAt || block.timestamp <= expiredAt;
     }
 }

--- a/contracts/bases/QuoteVerifierBase.sol
+++ b/contracts/bases/QuoteVerifierBase.sol
@@ -152,21 +152,22 @@ abstract contract QuoteVerifierBase is IQuoteVerifier, EnclaveIdBase, X509ChainB
     }
 
     function checkCollateralHashes(uint256 offset, bytes calldata journal) internal view returns (bool) {
-        bytes32 rootCaHash = bytes32(journal[offset:offset + 32]);
-        bytes32 tcbSigningHash = bytes32(journal[offset + 32:offset + 64]);
-        bytes32 rootCaCrlHash = bytes32(journal[offset + 64:offset + 96]);
-        bytes32 pckCrlHash = bytes32(journal[offset + 96:offset + 128]);
+        uint64 timestamp = uint64(bytes8(journal[offset:offset + 8]));
+        bytes32 rootCaHash = bytes32(journal[offset + 72:offset + 104]);
+        bytes32 tcbSigningHash = bytes32(journal[offset + 104:offset + 136]);
+        bytes32 rootCaCrlHash = bytes32(journal[offset + 136:offset + 168]);
+        bytes32 pckCrlHash = bytes32(journal[offset + 168:offset + 200]);
 
-        (bool tcbSigningFound, bytes32 expectedTcbSigningHash) = pccsRouter.getCertHash(CA.SIGNING);
-        if (!tcbSigningFound || tcbSigningHash != expectedTcbSigningHash) {
+        bytes32 expectedTcbSigningHash = pccsRouter.getCertHashWithTimestamp(CA.SIGNING, timestamp);
+        if (tcbSigningHash != expectedTcbSigningHash) {
             return false;
         }
-        (bool rootCaFound, bytes32 expectedRootCaHash) = pccsRouter.getCertHash(CA.ROOT);
-        if (!rootCaFound || rootCaHash != expectedRootCaHash) {
+        bytes32 expectedRootCaHash = pccsRouter.getCertHashWithTimestamp(CA.ROOT, timestamp);
+        if (rootCaHash != expectedRootCaHash) {
             return false;
         }
-        (bool rootCrlFound, bytes32 expectedRootCrlHash) = pccsRouter.getCrlHash(CA.ROOT);
-        if (!rootCrlFound || rootCaCrlHash != expectedRootCrlHash) {
+        bytes32 expectedRootCrlHash = pccsRouter.getCrlHashWithTimestamp(CA.ROOT, timestamp);
+        if (rootCaCrlHash != expectedRootCrlHash) {
             return false;
         }
 
@@ -177,17 +178,17 @@ abstract contract QuoteVerifierBase is IQuoteVerifier, EnclaveIdBase, X509ChainB
         // - the hash of the on-chain CRL matches with the CRL hash in the journal
 
         (bool platformSuccess, bytes memory platformRet) =
-            address(pccsRouter).staticcall(abi.encodeWithSelector(IPCCSRouter.getCrlHash.selector, CA.PLATFORM));
+            address(pccsRouter).staticcall(abi.encodeWithSelector(IPCCSRouter.getCrlHashWithTimestamp.selector, CA.PLATFORM, timestamp));
 
         (bool processorSuccess, bytes memory processorRet) =
-            address(pccsRouter).staticcall(abi.encodeWithSelector(IPCCSRouter.getCrlHash.selector, CA.PROCESSOR));
+            address(pccsRouter).staticcall(abi.encodeWithSelector(IPCCSRouter.getCrlHashWithTimestamp.selector, CA.PROCESSOR, timestamp));
 
         bytes32 expectedPlatformCrlHash;
         bytes32 expectedProcessorCrlHash;
         if (platformSuccess) {
-            (, expectedPlatformCrlHash) = abi.decode(platformRet, (bool, bytes32));
+            expectedPlatformCrlHash = abi.decode(platformRet, (bytes32));
         } else if (processorSuccess) {
-            (, expectedProcessorCrlHash) = abi.decode(processorRet, (bool, bytes32));
+            expectedProcessorCrlHash = abi.decode(processorRet, (bytes32));
         } else {
             // Both Processor and Platform PCKs not found
             return false;

--- a/contracts/interfaces/IPCCSRouter.sol
+++ b/contracts/interfaces/IPCCSRouter.sol
@@ -55,4 +55,9 @@ interface IPCCSRouter {
     function getCertHash(CA ca) external view returns (bool, bytes32);
 
     function getCrlHash(CA ca) external view returns (bool, bytes32);
+
+    // *withTimestamp() methods to check collateral expiration status based on the provided timestamp
+    function getCertHashWithTimestamp(CA ca, uint64 timestamp) external view returns (bytes32);
+
+    function getCrlHashWithTimestamp(CA ca, uint64 timestamp) external view returns (bytes32);
 }

--- a/contracts/verifiers/V3QuoteVerifier.sol
+++ b/contracts/verifiers/V3QuoteVerifier.sol
@@ -19,7 +19,7 @@ contract V3QuoteVerifier is QuoteVerifierBase, TCBInfoV2Base {
         returns (bool success, bytes memory output)
     {
         uint256 offset = 2 + uint16(bytes2(outputBytes[0:2]));
-        success = checkCollateralHashes(offset + 72, outputBytes);
+        success = checkCollateralHashes(offset, outputBytes);
         if (success) {
             output = outputBytes[2:offset];
         } else {

--- a/contracts/verifiers/V4QuoteVerifier.sol
+++ b/contracts/verifiers/V4QuoteVerifier.sol
@@ -40,7 +40,7 @@ contract V4QuoteVerifier is QuoteVerifierBase, TCBInfoV3Base, TDXModuleBase {
 
         uint256 offset = 2 + uint16(bytes2(outputBytes[0:2]));
 
-        success = checkCollateralHashes(offset + 72, outputBytes);
+        success = checkCollateralHashes(offset, outputBytes);
         if (success) {
             output = outputBytes[2:offset];
         } else {


### PR DESCRIPTION
Changes made in this PR:
- PCCS Router checks expiration of all collateral reads.
- For full collateral data reads, `block.timestamp` is used.
- For collateral hash reads, the user has the option to either use `block.timestamp` or with a specified timestamp by calling `*withTimestamp()` methods.
- `verifyAndAttestWithZKProof` no longer bypasses the `timestamp` value provided in the Output data. `timestamp` is then passed onto `*withTimestamp()` methods to check the expiration status of corresponding collaterals.

This PR partially addresses issue ID-5.