### PR TITLE
[TOB] DEV-3784: ID-5

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,4 +10,4 @@
 [submodule "lib/automata-on-chain-pccs"]
 	path = lib/automata-on-chain-pccs
 	url = https://github.com/automata-network/automata-on-chain-pccs
-	branch = main
+	branch = DEV-3784

--- a/contracts/bases/X509ChainBase.sol
+++ b/contracts/bases/X509ChainBase.sol
@@ -91,12 +91,12 @@ abstract contract X509ChainBase is P256Verifier {
                 }
             }
 
-            bytes20 issuerSubjectKeyIdentifier = issuer.subjectKeyIdentifier;
+            bytes memory issuerSubjectKeyIdentifier = issuer.subjectKeyIdentifier;
 
             if (crl.length > 0) {
                 // check issuer subject key identifier against crl authority key identifier
-                bytes20 crlAuthorityKeyIdentifier = crlHelper.getAuthorityKeyIdentifier(crl);
-                if (issuerSubjectKeyIdentifier != crlAuthorityKeyIdentifier) {
+                bytes memory crlAuthorityKeyIdentifier = crlHelper.getAuthorityKeyIdentifier(crl);
+                if (!BytesUtils.compareBytes(issuerSubjectKeyIdentifier, crlAuthorityKeyIdentifier)) {
                     return false;
                 }
                 certRevoked = crlHelper.serialNumberIsRevoked(current.serialNumber, crl);
@@ -111,8 +111,8 @@ abstract contract X509ChainBase is P256Verifier {
             }
 
             {
-                bytes20 currentAuthorityKeyIdentifier = current.authorityKeyIdentifier;
-                if (currentAuthorityKeyIdentifier == issuerSubjectKeyIdentifier) {
+                bytes memory currentAuthorityKeyIdentifier = current.authorityKeyIdentifier;
+                if (BytesUtils.compareBytes(issuerSubjectKeyIdentifier, currentAuthorityKeyIdentifier)) {
                      verified = ecdsaVerify(sha256(current.tbs), current.signature, issuer.subjectPublicKey);
                 }
                 if (!verified) {

--- a/contracts/bases/X509ChainBase.sol
+++ b/contracts/bases/X509ChainBase.sol
@@ -69,17 +69,18 @@ abstract contract X509ChainBase is P256Verifier {
         bool verified;
         bool certChainCanBeTrusted;
         for (uint256 i = 0; i < n; i++) {
+            X509CertObj memory current = certs[i];
             X509CertObj memory issuer;
+            bytes memory crl;
             if (i == n - 1) {
                 // rootCA
-                issuer = certs[i];
+                issuer = current;
             } else {
                 issuer = certs[i + 1];
-                bytes memory crl;
                 if (i == n - 2) {
                     (, crl) = pccsRouter.getCrl(CA.ROOT);
                 } else if (i == 0) {
-                    string memory issuerName = certs[i].issuerCommonName;
+                    string memory issuerName = current.issuerCommonName;
                     if (LibString.eq(issuerName, PLATFORM_ISSUER_NAME)) {
                         (, crl) = pccsRouter.getCrl(CA.PLATFORM);
                     } else if (LibString.eq(issuerName, PROCESSOR_ISSUER_NAME)) {
@@ -88,21 +89,32 @@ abstract contract X509ChainBase is P256Verifier {
                         return false;
                     }
                 }
-                if (crl.length > 0) {
-                    certRevoked = crlHelper.serialNumberIsRevoked(certs[i].serialNumber, crl);
-                }
-                if (certRevoked) {
-                    break;
-                }
             }
 
-            certNotExpired = block.timestamp > certs[i].validityNotBefore && block.timestamp < certs[i].validityNotAfter;
+            bytes20 issuerSubjectKeyIdentifier = issuer.subjectKeyIdentifier;
+
+            if (crl.length > 0) {
+                // check issuer subject key identifier against crl authority key identifier
+                bytes20 crlAuthorityKeyIdentifier = crlHelper.getAuthorityKeyIdentifier(crl);
+                if (issuerSubjectKeyIdentifier != crlAuthorityKeyIdentifier) {
+                    return false;
+                }
+                certRevoked = crlHelper.serialNumberIsRevoked(current.serialNumber, crl);
+            }
+            if (certRevoked) {
+                break;
+            }
+
+            certNotExpired = block.timestamp > current.validityNotBefore && block.timestamp < current.validityNotAfter;
             if (!certNotExpired) {
                 break;
             }
 
             {
-                verified = ecdsaVerify(sha256(certs[i].tbs), certs[i].signature, issuer.subjectPublicKey);
+                bytes20 currentAuthorityKeyIdentifier = current.authorityKeyIdentifier;
+                if (currentAuthorityKeyIdentifier == issuerSubjectKeyIdentifier) {
+                     verified = ecdsaVerify(sha256(current.tbs), current.signature, issuer.subjectPublicKey);
+                }
                 if (!verified) {
                     break;
                 }


### PR DESCRIPTION
See https://github.com/automata-network/automata-on-chain-pccs/pull/22 for more details about `authorityKeyIdentifier` and `subjectKeyIdentifier` fields introduced to the `X509Helper` and `X509CRLHelper` libraries.

This PR introduces two changes:
- `authorityKeyIdentifier` value of the CRL must match with the `subjectKeyIdentifier` value of the CA Issuer. This is cheaper than performing ECDSA verification (assuming not using RIP-7212).
- `authorityKeyIdentifier` value of a subject certificate must match with the `subjectKeyIdentifier` value of the CA issuer before performing ECDSA verification. 

ID-5 also raises issues regarding CRL expiration check, which is being resolved in #19.