### PR TITLE
[TOB] DEV-3789: ID-11

### DIFF
--- a/contracts/bases/QuoteVerifierBase.sol
+++ b/contracts/bases/QuoteVerifierBase.sol
@@ -152,11 +152,6 @@ abstract contract QuoteVerifierBase is IQuoteVerifier, EnclaveIdBase, X509ChainB
     }
 
     function checkCollateralHashes(uint256 offset, bytes calldata zkOutput) internal view returns (bool, bytes memory) {
-        uint256 expectedLength = offset + 128;
-        if (expectedLength != zkOutput.length) {
-            return (false, "zkOutput collateral does not match the expected length");
-        }
-        
         string memory mismatchMessage = "collateral mismatch";
         bytes32 rootCaHash = bytes32(zkOutput[offset:offset + 32]);
         bytes32 tcbSigningHash = bytes32(zkOutput[offset + 32:offset + 64]);

--- a/contracts/bases/QuoteVerifierBase.sol
+++ b/contracts/bases/QuoteVerifierBase.sol
@@ -151,30 +151,36 @@ abstract contract QuoteVerifierBase is IQuoteVerifier, EnclaveIdBase, X509ChainB
         );
     }
 
-    function checkCollateralHashes(uint256 offset, bytes calldata journal) internal view returns (bool) {
-        bytes32 rootCaHash = bytes32(journal[offset:offset + 32]);
-        bytes32 tcbSigningHash = bytes32(journal[offset + 32:offset + 64]);
-        bytes32 rootCaCrlHash = bytes32(journal[offset + 64:offset + 96]);
-        bytes32 pckCrlHash = bytes32(journal[offset + 96:offset + 128]);
+    function checkCollateralHashes(uint256 offset, bytes calldata zkOutput) internal view returns (bool, bytes memory) {
+        uint256 expectedLength = offset + 128;
+        if (expectedLength != zkOutput.length) {
+            return (false, "zkOutput collateral does not match the expected length");
+        }
+        
+        string memory mismatchMessage = "collateral mismatch";
+        bytes32 rootCaHash = bytes32(zkOutput[offset:offset + 32]);
+        bytes32 tcbSigningHash = bytes32(zkOutput[offset + 32:offset + 64]);
+        bytes32 rootCaCrlHash = bytes32(zkOutput[offset + 64:offset + 96]);
+        bytes32 pckCrlHash = bytes32(zkOutput[offset + 96:offset + 128]);
 
         (bool tcbSigningFound, bytes32 expectedTcbSigningHash) = pccsRouter.getCertHash(CA.SIGNING);
         if (!tcbSigningFound || tcbSigningHash != expectedTcbSigningHash) {
-            return false;
+            return (false, bytes(mismatchMessage));
         }
         (bool rootCaFound, bytes32 expectedRootCaHash) = pccsRouter.getCertHash(CA.ROOT);
         if (!rootCaFound || rootCaHash != expectedRootCaHash) {
-            return false;
+            return (false, bytes(mismatchMessage));
         }
         (bool rootCrlFound, bytes32 expectedRootCrlHash) = pccsRouter.getCrlHash(CA.ROOT);
         if (!rootCrlFound || rootCaCrlHash != expectedRootCrlHash) {
-            return false;
+            return (false, bytes(mismatchMessage));
         }
 
         // use low level calls for PCK CRLs, because we don't know which one of the CAs is used
         // to verify the quote
         // we can catch reverts here, and consider it a valid quote as long as:
         // - one of the PCK CAs has a CRL stored on-chain
-        // - the hash of the on-chain CRL matches with the CRL hash in the journal
+        // - the hash of the on-chain CRL matches with the CRL hash in the zkOutput
 
         (bool platformSuccess, bytes memory platformRet) =
             address(pccsRouter).staticcall(abi.encodeWithSelector(IPCCSRouter.getCrlHash.selector, CA.PLATFORM));
@@ -190,9 +196,10 @@ abstract contract QuoteVerifierBase is IQuoteVerifier, EnclaveIdBase, X509ChainB
             (, expectedProcessorCrlHash) = abi.decode(processorRet, (bool, bytes32));
         } else {
             // Both Processor and Platform PCKs not found
-            return false;
+            return (false, bytes(mismatchMessage));
         }
 
-        return pckCrlHash == expectedPlatformCrlHash || pckCrlHash == expectedProcessorCrlHash;
+        bool crlHashMatched = pckCrlHash == expectedPlatformCrlHash || pckCrlHash == expectedProcessorCrlHash;
+        return (crlHashMatched, crlHashMatched ? bytes("") : bytes(mismatchMessage));
     }
 }

--- a/contracts/types/Constants.sol
+++ b/contracts/types/Constants.sol
@@ -15,3 +15,7 @@ uint16 constant TD_REPORT10_LENGTH = 584;
 // + QE_REPORT_SIGNATURE (64 bytes) + QE_AUTH_DATA_SIZE (2 bytes) + QE_CERT_DATA_TYPE (2 bytes)
 // + QE_CERT_DATA_SIZE (4 bytes)
 uint16 constant MINIMUM_QUOTE_LENGTH = 1020;
+
+// timestamp + tcb_info_hash + identity_hash + root_ca_hash + tcb_signing_hash + root_crl_hash + pck_crl_hash
+// 8 + 6 * 32 = 200
+uint16 constant VERIFIED_OUTPUT_COLLATERAL_HASHES_LENGTH = 200;

--- a/contracts/types/Constants.sol
+++ b/contracts/types/Constants.sol
@@ -9,13 +9,9 @@ bytes4 constant TDX_TEE = 0x00000081;
 bytes16 constant VALID_QE_VENDOR_ID = 0x939a7233f79c4ca9940a0db3957f0607;
 uint16 constant ENCLAVE_REPORT_LENGTH = 384;
 uint16 constant TD_REPORT10_LENGTH = 584;
-uint16 constant TD_REPORT15_LENGTH = 648;
 
 // Header (48 bytes) + Body (minimum 384 bytes) + AuthDataSize (4 bytes) + AuthData:
 // ECDSA_SIGNATURE (64 bytes) + ECDSA_KEY (64 bytes) + QE_REPORT_BYTES (384 bytes)
 // + QE_REPORT_SIGNATURE (64 bytes) + QE_AUTH_DATA_SIZE (2 bytes) + QE_CERT_DATA_TYPE (2 bytes)
 // + QE_CERT_DATA_SIZE (4 bytes)
 uint16 constant MINIMUM_QUOTE_LENGTH = 1020;
-
-// QUOTE_VERSION (2 bytes) + TEE_TYPE (4 bytes) + TCB_STATUS (1 byte) + FMSPC (6 bytes)
-uint16 constant MINIMUM_OUTPUT_LENGTH = 13;

--- a/contracts/verifiers/V3QuoteVerifier.sol
+++ b/contracts/verifiers/V3QuoteVerifier.sol
@@ -18,7 +18,11 @@ contract V3QuoteVerifier is QuoteVerifierBase, TCBInfoV2Base {
         override
         returns (bool success, bytes memory output)
     {
-        uint256 offset = 2 + uint16(bytes2(outputBytes[0:2]));
+        uint16 outputLength = uint16(bytes2(outputBytes[0:2]));
+        uint256 offset = 2 + outputLength;
+        if (offset + VERIFIED_OUTPUT_COLLATERAL_HASHES_LENGTH != outputBytes.length) {
+            return (false, "invalid output length");
+        }
         (success, output) = checkCollateralHashes(offset + 72, outputBytes);
     }
 

--- a/contracts/verifiers/V3QuoteVerifier.sol
+++ b/contracts/verifiers/V3QuoteVerifier.sol
@@ -19,12 +19,7 @@ contract V3QuoteVerifier is QuoteVerifierBase, TCBInfoV2Base {
         returns (bool success, bytes memory output)
     {
         uint256 offset = 2 + uint16(bytes2(outputBytes[0:2]));
-        success = checkCollateralHashes(offset + 72, outputBytes);
-        if (success) {
-            output = outputBytes[2:offset];
-        } else {
-            output = bytes("Found one or more collaterals mismatch");
-        }
+        (success, output) = checkCollateralHashes(offset + 72, outputBytes);
     }
 
     function verifyQuote(Header calldata header, bytes calldata rawQuote)
@@ -65,14 +60,16 @@ contract V3QuoteVerifier is QuoteVerifierBase, TCBInfoV2Base {
         uint256 offset = HEADER_LENGTH + ENCLAVE_REPORT_LENGTH;
         (success, localReport) = parseEnclaveReport(quote[HEADER_LENGTH:offset]);
         if (!success) {
-            return (false, "failed to parse local isv report", parsed, rawQeReport);
+            return (false, "local isv report length is incorrect", parsed, rawQeReport);
         }
 
         // check authData length
         uint256 localAuthDataSize = BELE.leBytesToBeUint(quote[offset:offset + 4]);
         offset += 4;
+        // we don't strictly require the auth data to be equal to the provided length
+        // but this ignores any trailing bytes after the indicated length allocated for authData
         if (quote.length - offset < localAuthDataSize) {
-            return (false, "quote length is incorrect", parsed, rawQeReport);
+            return (false, "quote auth data length is incorrect", parsed, rawQeReport);
         }
 
         // at this point, we have verified the length of the entire quote to be correct

--- a/contracts/verifiers/V4QuoteVerifier.sol
+++ b/contracts/verifiers/V4QuoteVerifier.sol
@@ -38,8 +38,11 @@ contract V4QuoteVerifier is QuoteVerifierBase, TCBInfoV3Base, TDXModuleBase {
             return (false, bytes("Unknown TEE type"));
         }
 
-        uint256 offset = 2 + uint16(bytes2(outputBytes[0:2]));
-
+        uint16 outputLength = uint16(bytes2(outputBytes[0:2]));
+        uint256 offset = 2 + outputLength;
+        if (offset + VERIFIED_OUTPUT_COLLATERAL_HASHES_LENGTH != outputBytes.length) {
+            return (false, "invalid output length");
+        }
         (success, output) = checkCollateralHashes(offset + 72, outputBytes);
     }
 


### PR DESCRIPTION
Explicit length checks on the following:
- Quote Header length
- Quote AuthBody Length
- Local ISV Report Length
- Local TD_10 Report Length
- Quote auth_data Length
- zkVM Output collateral hashes length check

The goal of this PR is to avoid `out-of-bound` panics to reduce unnecessary debugging efforts.