### PR TITLE
[TOB] DEV-3787/3788: ID-8 and ID-10

### DIFF
--- a/contracts/AttestationEntrypointBase.sol
+++ b/contracts/AttestationEntrypointBase.sol
@@ -167,7 +167,7 @@ abstract contract AttestationEntrypointBase is Ownable {
         header = Header({
             version: uint16(BELE.leBytesToBeUint(rawQuote[0:2])),
             attestationKeyType: attestationKeyType,
-            teeType: bytes4(uint32(BELE.leBytesToBeUint(rawQuote[4:8]))),
+            teeType: bytes4(rawQuote[4:8]),
             qeSvn: qeSvn,
             pceSvn: pceSvn,
             qeVendorId: qeVendorId,

--- a/contracts/bases/QuoteVerifierBase.sol
+++ b/contracts/bases/QuoteVerifierBase.sol
@@ -142,9 +142,7 @@ abstract contract QuoteVerifierBase is IQuoteVerifier, EnclaveIdBase, X509ChainB
 
     function serializeOutput(Output memory output) internal pure returns (bytes memory) {
         return abi.encodePacked(
-            output.quoteVersion, 
-            // // TEMP
-            // uint32(BELE.leBytesToBeUint(abi.encodePacked(output.tee))), 
+            output.quoteVersion,
             output.tee,
             output.tcbStatus, 
             output.fmspcBytes, 

--- a/contracts/bases/QuoteVerifierBase.sol
+++ b/contracts/bases/QuoteVerifierBase.sol
@@ -143,7 +143,9 @@ abstract contract QuoteVerifierBase is IQuoteVerifier, EnclaveIdBase, X509ChainB
     function serializeOutput(Output memory output) internal pure returns (bytes memory) {
         return abi.encodePacked(
             output.quoteVersion, 
-            output.tee, 
+            // // TEMP
+            // uint32(BELE.leBytesToBeUint(abi.encodePacked(output.tee))), 
+            output.tee,
             output.tcbStatus, 
             output.fmspcBytes, 
             output.quoteBody, 

--- a/contracts/bases/TDXModuleBase.sol
+++ b/contracts/bases/TDXModuleBase.sol
@@ -11,8 +11,8 @@ abstract contract TDXModuleBase {
     function checkTdxModule(
         bytes memory mrsignerSeam,
         bytes memory expectedMrsignerSeam,
-        bytes8 seamAttributes,
-        bytes8 expectedSeamAttributes
+        uint64 seamAttributes,
+        uint64 expectedSeamAttributes
     ) internal pure returns (bool) {
         return mrsignerSeam.equals(expectedMrsignerSeam) && seamAttributes == expectedSeamAttributes;
     }

--- a/contracts/bases/tcb/TCBInfoV3Base.sol
+++ b/contracts/bases/tcb/TCBInfoV3Base.sol
@@ -7,6 +7,7 @@ import {
     TDXModuleIdentity,
     TDXModuleTCBLevelsObj
 } from "@automata-network/on-chain-pccs/helpers/FmspcTcbHelper.sol";
+import {BELE} from "../../utils/BELE.sol";
 import "./TCBInfoV2Base.sol";
 
 abstract contract TCBInfoV3Base is TCBInfoV2Base {
@@ -60,12 +61,12 @@ abstract contract TCBInfoV3Base is TCBInfoV2Base {
     function checkTdxModuleTcbStatus(bytes16 teeTcbSvn, TDXModuleIdentity[] memory tdxModuleIdentities)
         internal
         pure
-        returns (bool, TCBStatus, uint8, bytes memory, bytes8)
+        returns (bool, TCBStatus, uint8, bytes memory, uint64)
     {
         uint8 tdxModuleIsvSvn = uint8(teeTcbSvn[0]);
         uint8 tdxModuleVersion = uint8(teeTcbSvn[1]);
         bytes memory expectedMrSignerSeam;
-        bytes8 expectedSeamAttributes;
+        uint64 expectedSeamAttributes;
 
         if (tdxModuleVersion == 0) {
             return (true, TCBStatus.OK, tdxModuleVersion, expectedMrSignerSeam, expectedSeamAttributes);
@@ -87,7 +88,7 @@ abstract contract TCBInfoV3Base is TCBInfoV2Base {
                         tdxModuleIdentityFound = true;
                         moduleStatus = tdxModuleTcbLevels[j].status;
                         expectedMrSignerSeam = currId.mrsigner;
-                        expectedSeamAttributes = currId.attributes;
+                        expectedSeamAttributes = uint64(BELE.leBytesToBeUint(abi.encodePacked(currId.attributes)));
                         break;
                     }
                 }

--- a/contracts/types/CommonStruct.sol
+++ b/contracts/types/CommonStruct.sol
@@ -59,8 +59,8 @@ struct PCKCertTCB {
 }
 
 struct Output {
-    uint16 quoteVersion; // BE
-    bytes4 tee; // BE
+    uint16 quoteVersion; // BE (we should change this)
+    bytes4 tee; // BE (we should change this)
     TCBStatus tcbStatus;
     bytes6 fmspcBytes;
     bytes quoteBody;

--- a/contracts/types/CommonStruct.sol
+++ b/contracts/types/CommonStruct.sol
@@ -59,8 +59,8 @@ struct PCKCertTCB {
 }
 
 struct Output {
-    uint16 quoteVersion; // BE (we should change this)
-    bytes4 tee; // BE (we should change this)
+    uint16 quoteVersion;
+    bytes4 tee;
     TCBStatus tcbStatus;
     bytes6 fmspcBytes;
     bytes quoteBody;

--- a/contracts/types/Constants.sol
+++ b/contracts/types/Constants.sol
@@ -4,8 +4,9 @@ pragma solidity ^0.8.0;
 /// @dev https://github.com/intel/SGX-TDX-DCAP-QuoteVerificationLibrary/blob/16b7291a7a86e486fdfcf1dfb4be885c0cc00b4e/Src/AttestationLibrary/src/QuoteVerification/QuoteConstants.h
 uint16 constant HEADER_LENGTH = 48;
 bytes2 constant SUPPORTED_ATTESTATION_KEY_TYPE = 0x0200; // ECDSA_256_WITH_P256_CURVE (LE)
+// TEE_TYPE are little-endian encoded, hence reversing the order of bytes
 bytes4 constant SGX_TEE = 0x00000000;
-bytes4 constant TDX_TEE = 0x00000081;
+bytes4 constant TDX_TEE = 0x81000000;
 bytes16 constant VALID_QE_VENDOR_ID = 0x939a7233f79c4ca9940a0db3957f0607;
 uint16 constant ENCLAVE_REPORT_LENGTH = 384;
 uint16 constant TD_REPORT10_LENGTH = 584;

--- a/contracts/types/V4Structs.sol
+++ b/contracts/types/V4Structs.sol
@@ -8,9 +8,9 @@ struct TD10ReportBody {
     bytes16 teeTcbSvn;
     bytes mrSeam; // 48 bytes
     bytes mrsignerSeam; // 48 bytes
-    bytes8 seamAttributes;
-    bytes8 tdAttributes;
-    bytes8 xFAM;
+    uint64 seamAttributes;
+    uint64 tdAttributes;
+    uint64 xFAM;
     bytes mrTd; // 48 bytes
     bytes mrConfigId; // 48 bytes
     bytes mrOwner; // 48 bytes

--- a/contracts/verifiers/V4QuoteVerifier.sol
+++ b/contracts/verifiers/V4QuoteVerifier.sol
@@ -269,7 +269,7 @@ contract V4QuoteVerifier is QuoteVerifierBase, TCBInfoV3Base, TDXModuleBase {
         TCBStatus tdxModuleStatus;
         uint8 tdxModuleVersion;
         bytes memory expectedMrSignerSeam;
-        bytes8 expectedSeamAttributes;
+        uint64 expectedSeamAttributes;
         (success, tdxModuleStatus, tdxModuleVersion, expectedMrSignerSeam, expectedSeamAttributes) =
             checkTdxModuleTcbStatus(quote.reportBody.teeTcbSvn, ret.tdxModuleIdentities);
         if (!success || tdxModuleStatus == TCBStatus.TCB_REVOKED) {
@@ -308,9 +308,9 @@ contract V4QuoteVerifier is QuoteVerifierBase, TCBInfoV3Base, TDXModuleBase {
         report.teeTcbSvn = bytes16(reportBytes.substring(0, 16));
         report.mrSeam = reportBytes.substring(16, 48);
         report.mrsignerSeam = reportBytes.substring(64, 48);
-        report.seamAttributes = bytes8(uint64(BELE.leBytesToBeUint(reportBytes.substring(112, 8))));
-        report.tdAttributes = bytes8(uint64(BELE.leBytesToBeUint(reportBytes.substring(120, 8))));
-        report.xFAM = bytes8(uint64(BELE.leBytesToBeUint(reportBytes.substring(128, 8))));
+        report.seamAttributes = uint64(BELE.leBytesToBeUint(reportBytes.substring(112, 8)));
+        report.tdAttributes = uint64(BELE.leBytesToBeUint(reportBytes.substring(120, 8)));
+        report.xFAM = uint64(BELE.leBytesToBeUint(reportBytes.substring(128, 8)));
         report.mrTd = reportBytes.substring(136, 48);
         report.mrConfigId = reportBytes.substring(184, 48);
         report.mrOwner = reportBytes.substring(232, 48);


### PR DESCRIPTION
In this PR,

The endianness of TEE type shouldn't matter and is declared with a `bytes4` type, therefore eliminating the need for `leToBeUint()` conversion.

Any raw bytes that are being parsed, which requires the reversal of bytes must be declared as `uint*` types.

TL;DR:
- `bytes*` type if we don't care about endianness
- `uint*` type if we want to convert values to BE.