### PR TITLE
[TOB] DEV-3793: Content Hash Getters Added to PCCSRouter

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,4 +10,4 @@
 [submodule "lib/automata-on-chain-pccs"]
 	path = lib/automata-on-chain-pccs
 	url = https://github.com/automata-network/automata-on-chain-pccs
-	branch = main
+	branch = DEV-3793

--- a/contracts/AttestationEntrypointBase.sol
+++ b/contracts/AttestationEntrypointBase.sol
@@ -116,7 +116,11 @@ abstract contract AttestationEntrypointBase is Ownable {
      * @notice verifies an attestation using SNARK proofs
      * 
      * @param output - The output of the Guest program, this includes:
+     * - uint16 VerifiedOutput bytes length
      * - VerifiedOutput struct
+     * - uint64 timestamp (in seconds)
+     * - FMSPC TCB Info content hash
+     * - QEIdentity content hash
      * - RootCA hash
      * - TCB Signing CA hash
      * - Root CRL hash

--- a/contracts/PCCSRouter.sol
+++ b/contracts/PCCSRouter.sol
@@ -130,6 +130,17 @@ contract PCCSRouter is IPCCSRouter, Ownable {
         }
     }
 
+    function getQeIdentityContentHash(EnclaveId id, uint256 quoteVersion) 
+        external 
+        view 
+        override 
+        returns (bytes32 contentHash)
+    {
+        EnclaveIdentityDao enclaveIdDao = EnclaveIdentityDao(qeIdDaoAddr);
+        bytes32 key = enclaveIdDao.ENCLAVE_ID_KEY(uint256(id), quoteVersion);
+        contentHash = enclaveIdDao.getIdentityContentHash(key);
+    }
+
     function getFmspcTcbV2(bytes6 fmspc)
         external
         view
@@ -180,6 +191,17 @@ contract PCCSRouter is IPCCSRouter, Ownable {
         } else {
             revert FmspcTcbNotFound(id, 3);
         }
+    }
+
+    function getFmspcTcbContentHash(TcbId id, bytes6 fmspc, uint32 version) 
+        external 
+        view
+        override
+        returns (bytes32) 
+    {
+        FmspcTcbDao tcbDao = FmspcTcbDao(fmspcTcbDaoAddr);
+        bytes32 key = tcbDao.FMSPC_TCB_KEY(uint8(id), fmspc, version);
+        return tcbDao.getTcbInfoContentHash(key);
     }
 
     function getPckCert(

--- a/contracts/bases/QuoteVerifierBase.sol
+++ b/contracts/bases/QuoteVerifierBase.sol
@@ -1,7 +1,8 @@
 //SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {TCBStatus} from "@automata-network/on-chain-pccs/helpers/FmspcTcbHelper.sol";
+import {TCBStatus, TcbId} from "@automata-network/on-chain-pccs/helpers/FmspcTcbHelper.sol";
+import {EnclaveId} from "@automata-network/on-chain-pccs/helpers/EnclaveIdentityHelper.sol";
 
 import {IQuoteVerifier, IPCCSRouter} from "../interfaces/IQuoteVerifier.sol";
 import {BytesUtils} from "../utils/BytesUtils.sol";
@@ -152,19 +153,45 @@ abstract contract QuoteVerifierBase is IQuoteVerifier, EnclaveIdBase, X509ChainB
     }
 
     function checkCollateralHashes(uint256 offset, bytes calldata journal) internal view returns (bool) {
-        bytes32 rootCaHash = bytes32(journal[offset:offset + 32]);
-        bytes32 tcbSigningHash = bytes32(journal[offset + 32:offset + 64]);
-        bytes32 rootCaCrlHash = bytes32(journal[offset + 64:offset + 96]);
-        bytes32 pckCrlHash = bytes32(journal[offset + 96:offset + 128]);
+        uint64 timestamp = uint64(bytes8(journal[offset:offset + 8]));
+        bytes32 tcbInfoContentHash = bytes32(journal[offset + 8:offset + 40]);
+        bytes32 identityContentHash = bytes32(journal[offset + 40:offset + 72]);
+        bytes32 rootCaHash = bytes32(journal[offset + 72:offset + 104]);
+        bytes32 tcbSigningHash = bytes32(journal[offset + 104:offset + 136]);
+        bytes32 rootCaCrlHash = bytes32(journal[offset + 136:offset + 168]);
+        bytes32 pckCrlHash = bytes32(journal[offset + 168:offset + 200]);
+
+        bytes4 tee = bytes4(journal[4:8]);
+        bytes6 fmspc = bytes6(journal[9:15]);
+        bytes32 expectedTcbInfoContentHash = 
+            pccsRouter.getFmspcTcbContentHash(
+                tee == SGX_TEE ? TcbId.SGX : TcbId.TDX,
+                fmspc,
+                quoteVersion < 4 ? 2 : 3
+            );
+        if (tcbInfoContentHash != expectedTcbInfoContentHash) {
+            return false;
+        }
+
+        bytes32 expectedIdentityContentHash =
+            pccsRouter.getQeIdentityContentHash(
+                tee == SGX_TEE ? EnclaveId.QE : EnclaveId.TD_QE,
+                quoteVersion
+            );
+        if (identityContentHash != expectedIdentityContentHash) {
+            return false;
+        }
+
+        (bool rootCaFound, bytes32 expectedRootCaHash) = pccsRouter.getCertHash(CA.ROOT);
+        if (!rootCaFound || rootCaHash != expectedRootCaHash) {
+            return false;
+        }
 
         (bool tcbSigningFound, bytes32 expectedTcbSigningHash) = pccsRouter.getCertHash(CA.SIGNING);
         if (!tcbSigningFound || tcbSigningHash != expectedTcbSigningHash) {
             return false;
         }
-        (bool rootCaFound, bytes32 expectedRootCaHash) = pccsRouter.getCertHash(CA.ROOT);
-        if (!rootCaFound || rootCaHash != expectedRootCaHash) {
-            return false;
-        }
+        
         (bool rootCrlFound, bytes32 expectedRootCrlHash) = pccsRouter.getCrlHash(CA.ROOT);
         if (!rootCrlFound || rootCaCrlHash != expectedRootCrlHash) {
             return false;

--- a/contracts/interfaces/IPCCSRouter.sol
+++ b/contracts/interfaces/IPCCSRouter.sol
@@ -34,12 +34,16 @@ interface IPCCSRouter {
 
     function getQeIdentity(EnclaveId id, uint256 quoteVersion) external view returns (bool, IdentityObj memory);
 
+    function getQeIdentityContentHash(EnclaveId id, uint256 version) external view returns (bytes32);
+
     function getFmspcTcbV2(bytes6 fmspc) external view returns (bool, TCBLevelsObj[] memory);
 
     function getFmspcTcbV3(TcbId id, bytes6 fmspc)
         external
         view
         returns (bool, TCBLevelsObj[] memory, TDXModule memory, TDXModuleIdentity[] memory);
+
+    function getFmspcTcbContentHash(TcbId id, bytes6 fmspc, uint32 version) external view returns (bytes32);
 
     function getPckCert(
         string calldata qeid,

--- a/contracts/verifiers/V3QuoteVerifier.sol
+++ b/contracts/verifiers/V3QuoteVerifier.sol
@@ -19,7 +19,7 @@ contract V3QuoteVerifier is QuoteVerifierBase, TCBInfoV2Base {
         returns (bool success, bytes memory output)
     {
         uint256 offset = 2 + uint16(bytes2(outputBytes[0:2]));
-        success = checkCollateralHashes(offset + 72, outputBytes);
+        success = checkCollateralHashes(offset, outputBytes);
         if (success) {
             output = outputBytes[2:offset];
         } else {

--- a/contracts/verifiers/V4QuoteVerifier.sol
+++ b/contracts/verifiers/V4QuoteVerifier.sol
@@ -40,7 +40,7 @@ contract V4QuoteVerifier is QuoteVerifierBase, TCBInfoV3Base, TDXModuleBase {
 
         uint256 offset = 2 + uint16(bytes2(outputBytes[0:2]));
 
-        success = checkCollateralHashes(offset + 72, outputBytes);
+        success = checkCollateralHashes(offset, outputBytes);
         if (success) {
             output = outputBytes[2:offset];
         } else {

--- a/forge-test/utils/PCCSSetupBase.sol
+++ b/forge-test/utils/PCCSSetupBase.sol
@@ -117,7 +117,7 @@ abstract contract PCCSSetupBase is Test {
 
     function qeIdDaoUpsert(uint256 quoteVersion, string memory path) internal {
         EnclaveIdentityJsonObj memory identityJson = _readIdentityJson(path);
-        IdentityObj memory identity = enclaveIdHelper.parseIdentityString(identityJson.identityStr);
+        (IdentityObj memory identity,) = enclaveIdHelper.parseIdentityString(identityJson.identityStr);
         enclaveIdDao.upsertEnclaveIdentity(uint256(identity.id), quoteVersion, identityJson);
     }
 


### PR DESCRIPTION
The Content Hash getters are added to enable JSON collaterals checking for ZK Proofs. To learn more about why this is needed, read the comment added to this PR: https://github.com/automata-network/automata-on-chain-pccs/pull/27