### PR TITLE
Fix typos and clarify comments in Intel DCAP quote structs

### DIFF
--- a/evm/contracts/types/CommonStruct.sol
+++ b/evm/contracts/types/CommonStruct.sol
@@ -7,11 +7,11 @@ import {X509CertObj} from "@automata-network/on-chain-pccs/helpers/X509Helper.so
 /**
  * @title CommonStruct
  * @notice Structs that are common across different versions and TEE of Intel DCAP Quote
- * @dev may refer to Intel Official Documentation for more details on the struct definiton
+ * @dev May refer to Intel Official Documentation for more details on the struct definition
  * @dev Intel V3 SGX DCAP API Library: https://download.01.org/intel-sgx/sgx-dcap/1.22/linux/docs/Intel_SGX_ECDSA_QuoteLibReference_DCAP_API.pdf
  * @dev Intel V4 TDX DCAP API Library: https://download.01.org/intel-sgx/sgx-dcap/1.22/linux/docs/Intel_TDX_DCAP_Quoting_Library_API.pdf
  * @dev Fields that are declared as integers (uint*) must reverse the byte order to big-endian
- * @dev Whereas, fields that are declared as bytes* type do not reverse the byte order
+ * @dev Fields declared as `bytes*` types retain their byte order and do not require conversion
  */
 
 /**

--- a/evm/contracts/types/V4Structs.sol
+++ b/evm/contracts/types/V4Structs.sol
@@ -20,7 +20,7 @@ struct TD10ReportBody {
     bytes mrOwner; // 48 bytes
     bytes mrOwnerConfig; // 48 bytes
     bytes rtMr0; // 48 bytes
-    bytes rtMr1; // 48 nytes
+    bytes rtMr1; // 48 bytes
     bytes rtMr2; // 48 bytes
     bytes rtMr3; // 48 bytes
     bytes reportData; // 64 bytes


### PR DESCRIPTION
**Fixed typos**:
  - `definiton` → `definition` in `CommonStruct.sol`
  - `48 nytes` → `48 bytes` in `V4Structs.sol`

**Improved clarity**:
  - Rephrased the comment regarding `bytes*` field endianness for better readability.
