### PR TITLE
update actions/checkout from v3 to v4

### DIFF
--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -23,7 +23,7 @@ jobs:
         working-directory: evm
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Run Slither
         uses: crytic/slither-action@v0.4.0


### PR DESCRIPTION
Updates actions/checkout to the latest stable version v4.

Changes:

Updates all instances of actions/checkout@v3 to actions/checkout@v4
This is the last file requiring this update, all other files have been updated
Reference:
Latest version confirmation: https://github.com/actions/checkout/releases/tag/v4.2.2

This update ensures we're using the most recent stable version of the GitHub checkout action across our CI/CD pipelines.