### PR TITLE
Minor Fixes: Typo Correction in Docs & Makefile Echo Consistency

### DIFF
--- a/evm/Makefile
+++ b/evm/Makefile
@@ -202,7 +202,7 @@ help:
 	@echo "  deploy-all-verifiers   Deploy all QuoteVerifier contracts with versions that are currently supported"
 	@echo "  deploy-all             Deploy all contracts"
 	@echo "  verify-all             Verify all contracts"
-	@echo "  config-zk              zkVM Configuraton"
+	@echo "  config-zk              zkVM Configuration"
 	@echo "  config-verifier        QuoteVerifier Configuration"
 	@echo "  config-router          Set authorization for calling PCCSRouter"
 	@echo "  clean                  Remove build artifacts"

--- a/evm/contracts/types/CommonStruct.sol
+++ b/evm/contracts/types/CommonStruct.sol
@@ -7,7 +7,7 @@ import {X509CertObj} from "@automata-network/on-chain-pccs/helpers/X509Helper.so
 /**
  * @title CommonStruct
  * @notice Structs that are common across different versions and TEE of Intel DCAP Quote
- * @dev may refer to Intel Official Documentation for more details on the struct definiton
+ * @dev may refer to Intel Official Documentation for more details on the struct definition
  * @dev Intel V3 SGX DCAP API Library: https://download.01.org/intel-sgx/sgx-dcap/1.22/linux/docs/Intel_SGX_ECDSA_QuoteLibReference_DCAP_API.pdf
  * @dev Intel V4 TDX DCAP API Library: https://download.01.org/intel-sgx/sgx-dcap/1.22/linux/docs/Intel_TDX_DCAP_Quoting_Library_API.pdf
  * @dev Fields that are declared as integers (uint*) must reverse the byte order to big-endian


### PR DESCRIPTION


**Description:**  
- Fixed a typo in the `CommonStruct.sol` documentation (`definiton` → `definition`).
- Updated the `Makefile` to ensure consistent echo formatting for the `config-zk` command.

