### PR TITLE
Fix collateral validity check; unify verifier error types; minor comment typos

### DIFF
--- a/evm/contracts/AttestationEntrypointBase.sol
+++ b/evm/contracts/AttestationEntrypointBase.sol
@@ -79,7 +79,7 @@ abstract contract AttestationEntrypointBase is Ownable {
     /**
      * @param zkCoProcessorType 1 - RiscZero, 2 - Succinct... etc.
      * @return this is either the IMAGE_ID for RiscZero Guest Program or
-     * Succiinct Program Verifying Key
+     * Succinct Program Verifying Key
      */
     function programIdentifier(uint8 zkCoProcessorType) external view returns (bytes32) {
         return _zkConfig[ZkCoProcessorType(zkCoProcessorType)].dcapProgramIdentifier;

--- a/evm/contracts/PCCSRouter.sol
+++ b/evm/contracts/PCCSRouter.sol
@@ -312,7 +312,7 @@ contract PCCSRouter is IPCCSRouter, Ownable {
         require(success, "Failed to determine collateral validity");
         if (ret.length > 0) {
             (uint64 issuedAt, uint64 expiredAt) = abi.decode(ret, (uint64, uint64));
-            valid = timestamp >= issuedAt || timestamp <= expiredAt;
+            valid = timestamp >= issuedAt && timestamp <= expiredAt;
         }
     }
 }

--- a/evm/contracts/bases/FeeManagerBase.sol
+++ b/evm/contracts/bases/FeeManagerBase.sol
@@ -53,7 +53,7 @@ abstract contract FeeManagerBase {
             if (excess > 0) {
                 // refund the sender, rather than the caller
                 // @dev may fail subsequent call(s), if the caller were a contract
-                // that might need to make subsequent calls requiring ETh transfers
+                // that might need to make subsequent calls requiring ETH transfers
                 _refund(tx.origin, excess);
             }
         }

--- a/evm/contracts/verifiers/V3QuoteVerifier.sol
+++ b/evm/contracts/verifiers/V3QuoteVerifier.sol
@@ -20,7 +20,7 @@ contract V3QuoteVerifier is QuoteVerifierBase, TCBInfoV2Base {
         uint16 outputLength = uint16(bytes2(outputBytes[0:2]));
         uint256 offset = 2 + outputLength;
         if (offset + VERIFIED_OUTPUT_COLLATERAL_HASHES_LENGTH != outputBytes.length) {
-            return (false, "invalid output length");
+            return (false, bytes("invalid output length"));
         }
         bytes memory errorMessage;
         (success, errorMessage) = checkCollateralHashes(offset, outputBytes);
@@ -124,7 +124,7 @@ contract V3QuoteVerifier is QuoteVerifierBase, TCBInfoV2Base {
             }
         }
         if (!statusFound || tcbStatus == TCBStatus.TCB_REVOKED) {
-            return (statusFound, bytes("Verificaton failed by TCBInfo check"));
+            return (statusFound, bytes("Verification failed by TCBInfo check"));
         }
 
         // Step 3: Converge QEIdentity and FMSPC TCB Status

--- a/evm/contracts/verifiers/V4QuoteVerifier.sol
+++ b/evm/contracts/verifiers/V4QuoteVerifier.sol
@@ -40,7 +40,7 @@ contract V4QuoteVerifier is QuoteVerifierBase, TCBInfoV3Base, TDXModuleBase {
         uint16 outputLength = uint16(bytes2(outputBytes[0:2]));
         uint256 offset = 2 + outputLength;
         if (offset + VERIFIED_OUTPUT_COLLATERAL_HASHES_LENGTH != outputBytes.length) {
-            return (false, "invalid output length");
+            return (false, bytes("invalid output length"));
         }
         bytes memory errorMessage;
         (success, errorMessage) = checkCollateralHashes(offset, outputBytes);


### PR DESCRIPTION
- **Fix**: Correct collateral validity window in `PCCSRouter._loadDataIfNotExpired` to `issuedAt <= timestamp <= expiredAt` (AND instead of OR).
- **Verifiers**: Return `bytes` for error messages in `verifyZkOutput` (V3/V4) to match function signatures; fix typo in V3 error text.
- **Docs**: Comment typos fixed (“Succinct”, “ETH”).

### Impact
- Prevents accepting expired/not-yet-valid collaterals.
- No storage/layout changes; backwards-compatible interface-wise.

### Files
- `evm/contracts/PCCSRouter.sol`
- `evm/contracts/verifiers/V3QuoteVerifier.sol`
- `evm/contracts/verifiers/V4QuoteVerifier.sol`
- `evm/contracts/AttestationEntrypointBase.sol`
- `evm/contracts/bases/FeeManagerBase.sol`

### Testing
- Built with Foundry; tests executed and passed prior to push.