### PR TITLE
Stop double-hashing P-256 message digest in P256Configuration

### DIFF
--- a/evm/forge-script/utils/P256Configuration.sol
+++ b/evm/forge-script/utils/P256Configuration.sol
@@ -22,7 +22,7 @@ contract P256Configuration is Script {
     }
 
     function simulateVerify() public returns (address verifier) {
-        bytes memory data = abi.encodePacked(sha256(test_message), test_sig, test_pubkey);
+        bytes memory data = abi.encodePacked(test_message, test_sig, test_pubkey);
 
         bool precompileVerified = verifyWithFfi(RIP7212_P256_PRECOMPILE, data);
 


### PR DESCRIPTION
The RIP-7212 P256 precompile (and Daimo implementation) expects a 32-byte message digest as input. simulateVerify was applying sha256 to an already 32-byte digest (test_message), resulting in double hashing and inevitable verification failures. This change removes the extra hash and passes the digest as-is to match the expected calldata format.