### PR TITLE
fix: use correct PCS API version in V3QuoteVerifier

### DIFF
--- a/evm/contracts/verifiers/V3QuoteVerifier.sol
+++ b/evm/contracts/verifiers/V3QuoteVerifier.sol
@@ -29,7 +29,7 @@ contract V3QuoteVerifier is QuoteVerifierBase, TCBInfoV2Base {
         bytes memory rawBody = rawQuote[HEADER_LENGTH:HEADER_LENGTH + ENCLAVE_REPORT_LENGTH];
 
         VerificationResult memory result =
-            _verifyQuoteIntegrity(4, tcbEvalNumber, SGX_TEE, rawHeader, rawBody, authData);
+            _verifyQuoteIntegrity(3, tcbEvalNumber, SGX_TEE, rawHeader, rawBody, authData);
         if (!result.success) {
             return (false, bytes(result.reason));
         }


### PR DESCRIPTION
Wrong pcsApiVersion passed to _verifyQuoteIntegrity — was 4, should be 3 for Quote V3.

Spotted by checking how V4/V5 verifiers do it and the formula in QuoteVerifierBase (quoteVersion < 4 ? 3 : 4).