### PR TITLE
fix: fix typos and copy-paste errors

### DIFF
--- a/rust-crates/libraries/dcap-rs/src/types/pod/tcb_info/tests.rs
+++ b/rust-crates/libraries/dcap-rs/src/types/pod/tcb_info/tests.rs
@@ -329,7 +329,7 @@ fn test_tcb_v3_tdx_bytemuck() {
     let parsed_tcb_info_hash = Sha256::digest(parsed_tcb_info_string.as_bytes());
     assert_eq!(
         original_tcb_info_hash, parsed_tcb_info_hash,
-        "Parsed TcbInfoV2 hash does not match original"
+        "Parsed TcbInfoV3 TDX hash does not match original"
     );
 
     // Test ZeroCopy for TcbV3 TDX

--- a/rust-crates/libraries/dcap-rs/src/types/pod/tcb_info/tests.rs
+++ b/rust-crates/libraries/dcap-rs/src/types/pod/tcb_info/tests.rs
@@ -176,7 +176,7 @@ fn test_tcb_v3_sgx_bytemuck() {
     let parsed_tcb_info_hash = Sha256::digest(parsed_tcb_info_string.as_bytes());
     assert_eq!(
         original_tcb_info_hash, parsed_tcb_info_hash,
-        "Parsed TcbInfoV2 hash does not match original"
+        "Parsed TcbInfoV3 SGX hash does not match original"
     );
 
     // Test ZeroCopy for TcbV3 SGX

--- a/rust-crates/libraries/dcap-rs/src/types/pod/tcb_info/tests.rs
+++ b/rust-crates/libraries/dcap-rs/src/types/pod/tcb_info/tests.rs
@@ -325,7 +325,7 @@ fn test_tcb_v3_tdx_bytemuck() {
     let original_tcb_info_hash =
         Sha256::digest(tcb_info_and_signature.tcb_info_raw.get().as_bytes());
     let parsed_tcb_info_string = serde_json::to_string(&parsed_tcb_info)
-        .expect("Failed to serialize parsed TcbInfoV3 SGX to JSON string");
+        .expect("Failed to serialize parsed TcbInfoV3 TDX to JSON string");
     let parsed_tcb_info_hash = Sha256::digest(parsed_tcb_info_string.as_bytes());
     assert_eq!(
         original_tcb_info_hash, parsed_tcb_info_hash,

--- a/rust-crates/libraries/dcap-rs/src/types/pod/tcb_info/zero_copy/structs.rs
+++ b/rust-crates/libraries/dcap-rs/src/types/pod/tcb_info/zero_copy/structs.rs
@@ -1,7 +1,7 @@
 // src/types/pod/tcb_info/zero_copy/structs.rs
 
 use super::error::ZeroCopyError;
-use super::iterators::*; // Will define iterators later
+use super::iterators::*;
 use crate::types::pod::tcb_info::{
     TcbComponentHeader, TcbInfoHeader, TcbLevelHeader, TdxModuleIdentityHeader, TdxModulePodData,
     TdxTcbLevelHeader,

--- a/rust-crates/libraries/dcap-rs/src/types/quote/signature.rs
+++ b/rust-crates/libraries/dcap-rs/src/types/quote/signature.rs
@@ -11,7 +11,7 @@ use super::{CertificationKeyType, PckCertChainData};
 
 /// Signature data for SGX Quotes
 ///
-/// In the intel docs, this is A 4.4: "ECDSA 256-bit Quote Signature Data Structure"
+/// In the Intel docs, this is A 4.4: "ECDSA 256-bit Quote Signature Data Structure"
 ///
 /// This can be used to validate that the quoting enclave itself is valid, and then that
 /// the quoting enclave has signed the ISV enclave report.

--- a/rust-crates/libraries/dcap-rs/src/types/quote/signature.rs
+++ b/rust-crates/libraries/dcap-rs/src/types/quote/signature.rs
@@ -11,7 +11,7 @@ use super::{CertificationKeyType, PckCertChainData};
 
 /// Signature data for SGX Quotes
 ///
-/// In the intel docs, this is A 4.4: "ECDSA 2560bit Quote Signature Data Structure"
+/// In the intel docs, this is A 4.4: "ECDSA 256-bit Quote Signature Data Structure"
 ///
 /// This can be used to validate that the quoting enclave itself is valid, and then that
 /// the quoting enclave has signed the ISV enclave report.


### PR DESCRIPTION
- Fix copy-paste errors in test assertion messages in tcb_info/tests.rs: wrong version
  identifiers (TcbInfoV2 → TcbInfoV3 SGX/TcbInfoV3 TDX, SGX → TDX)
 - Remove stale comment in tcb_info/zero_copy/structs.rs (// Will define iterators later —
  iterators already implemented)
 - Fix typo in quote/signature.rs doc comment (ECDSA 2560bit → ECDSA 256-bit, intel → Intel)