### PR TITLE
chore: fix typos and comment inaccuracies

### DIFF
--- a/rust-crates/libraries/dcap-rs/src/types/enclave_identity.rs
+++ b/rust-crates/libraries/dcap-rs/src/types/enclave_identity.rs
@@ -83,7 +83,7 @@ pub struct EnclaveIdentity {
     pub next_update: chrono::DateTime<Utc>,
 
     /// A monotonically increasing sequence number changed when Intel updates the content of the TCB evaluation data set:
-    /// TCB Info, QE Identity, QVE Identity. The tcbEvaluationDataNumber update is synchronized across TCB infor for all
+    /// TCB Info, QE Identity, QVE Identity. The tcbEvaluationDataNumber update is synchronized across TCB info for all
     /// flavours of SGX CPUs (Family-Model-Stepping-Platform-CustomSKU) and QE/QVE Identity.
     /// This sequence number allows users to easily determine when a particular TCB Info/QE Identity/QVE Identity
     /// superseedes another TCB Info/QE Identity/QVE Identity (value: current TCB Recovery event number stored in the database).

--- a/rust-crates/libraries/dcap-rs/src/types/enclave_identity.rs
+++ b/rust-crates/libraries/dcap-rs/src/types/enclave_identity.rs
@@ -86,7 +86,7 @@ pub struct EnclaveIdentity {
     /// TCB Info, QE Identity, QVE Identity. The tcbEvaluationDataNumber update is synchronized across TCB info for all
     /// flavours of SGX CPUs (Family-Model-Stepping-Platform-CustomSKU) and QE/QVE Identity.
     /// This sequence number allows users to easily determine when a particular TCB Info/QE Identity/QVE Identity
-    /// superseedes another TCB Info/QE Identity/QVE Identity (value: current TCB Recovery event number stored in the database).
+    /// supersedes another TCB Info/QE Identity/QVE Identity (value: current TCB Recovery event number stored in the database).
     pub tcb_evaluation_data_number: u32,
 
     /// Base 16-encoded string representing miscselect "golden" value (upon applying mask).

--- a/rust-crates/libraries/dcap-rs/src/types/enclave_identity.rs
+++ b/rust-crates/libraries/dcap-rs/src/types/enclave_identity.rs
@@ -83,7 +83,7 @@ pub struct EnclaveIdentity {
     pub next_update: chrono::DateTime<Utc>,
 
     /// A monotonically increasing sequence number changed when Intel updates the content of the TCB evaluation data set:
-    /// TCB Info, QE Identity, QVE Identity. The tcbEvaluationDataNUmber update is synchronized across TCB infor for all
+    /// TCB Info, QE Identity, QVE Identity. The tcbEvaluationDataNumber update is synchronized across TCB infor for all
     /// flavours of SGX CPUs (Family-Model-Stepping-Platform-CustomSKU) and QE/QVE Identity.
     /// This sequence number allows users to easily determine when a particular TCB Info/QE Identity/QVE Identity
     /// superseedes another TCB Info/QE Identity/QVE Identity (value: current TCB Recovery event number stored in the database).

--- a/rust-crates/libraries/dcap-rs/src/types/report.rs
+++ b/rust-crates/libraries/dcap-rs/src/types/report.rs
@@ -122,7 +122,7 @@ pub struct Td10ReportBody {
 
     // (128) XFAM (eXtended Features Available Mask) is defined as a 64b bitmap,
     // which has the same format as XCR0 or IA32_XSS MSR.
-    // uint8_t xfam[8§];
+    // uint8_t xfam[8];
     pub xfam: [u8; 8],
 
     // (136) Measurement of the initial contents of the TD.

--- a/rust-crates/libraries/dcap-rs/src/types/report.rs
+++ b/rust-crates/libraries/dcap-rs/src/types/report.rs
@@ -190,7 +190,7 @@ impl TryFrom<[u8; std::mem::size_of::<Td10ReportBody>()]> for Td10ReportBody {
 pub struct Td15ReportBody {
     pub td_report: Td10ReportBody,
 
-    /// (584) Describes the current TCB of TDX. This value may will be different than TEE_TCB_SVN by
+    /// (584) Describes the current TCB of TDX. This value may be different than TEE_TCB_SVN by
     /// loading a new version of the TDX Module using the TD Preserving update capability)
     pub tee_tcb_svn2: [u8; 16],
 


### PR DESCRIPTION
tcbEvaluationDataNUmber -> tcbEvaluationDataNumber
infor -> info
superseedes -> supersedes
int8_t xfam[8§] -> int8_t xfam[8]
value may will be different -> value may be different