### PR TITLE
fix: remove redundant clone() calls

### DIFF
--- a/rust-crates/libraries/dcap-rs/src/types/collateral.rs
+++ b/rust-crates/libraries/dcap-rs/src/types/collateral.rs
@@ -128,7 +128,7 @@ impl Collateral {
             CollateralSol::abi_decode_params(encoded)?;
 
         let mut pem_chain = String::new();
-        let tcb_pem = Pem::new(String::from("CERTIFICATE"), chain_bytes[0].to_vec().clone());
+        let tcb_pem = Pem::new(String::from("CERTIFICATE"), chain_bytes[0].to_vec());
 
         let root_pem = Pem::new(String::from("CERTIFICATE"), chain_bytes[1].to_vec().clone());
 

--- a/rust-crates/libraries/dcap-rs/src/types/collateral.rs
+++ b/rust-crates/libraries/dcap-rs/src/types/collateral.rs
@@ -130,7 +130,7 @@ impl Collateral {
         let mut pem_chain = String::new();
         let tcb_pem = Pem::new(String::from("CERTIFICATE"), chain_bytes[0].to_vec());
 
-        let root_pem = Pem::new(String::from("CERTIFICATE"), chain_bytes[1].to_vec().clone());
+        let root_pem = Pem::new(String::from("CERTIFICATE"), chain_bytes[1].to_vec());
 
         pem_chain.push_str(&encode(&tcb_pem));
         pem_chain.push_str(&encode(&root_pem));

--- a/rust-crates/libraries/dcap-rs/src/types/tcb_info.rs
+++ b/rust-crates/libraries/dcap-rs/src/types/tcb_info.rs
@@ -516,7 +516,7 @@ impl TcbStatus {
 
             let matched_tcb_level = match_tdx_tcb(td_report, tcb_info, index)?;
             tdx_tcb_status = matched_tcb_level.tcb_status;
-            advisory_ids = matched_tcb_level.advisory_ids.clone().unwrap_or_default();
+            advisory_ids = matched_tcb_level.advisory_ids.unwrap_or_default();
         }
 
         // Return the final status determination as a tuple

--- a/rust-crates/libraries/qpl/src/collaterals/helper.rs
+++ b/rust-crates/libraries/qpl/src/collaterals/helper.rs
@@ -613,7 +613,7 @@ pub fn sgx_ql_get_quote_verification_collateral<P: Provider>(
         let req_url = format!(
             "{}/sgx/certification/{}/pckcrl?ca={}",
             pccs_url,
-            collateral_version.clone(),
+            collateral_version,
             pck_ca.clone()
         );
         let rt = tokio::runtime::Builder::new_current_thread()
@@ -1087,7 +1087,7 @@ pub fn tdx_ql_get_quote_verification_collateral<P: Provider>(
                 pck_crl.as_str(),
                 tcb_info_str.as_str(),
                 enclave_id,
-                collateral_version.clone(),
+                collateral_version,
                 qe_identity_str.as_str(),
                 enclave_identity_issuer_chains_str.as_str(),
                 all_verification_collateral,
@@ -1230,7 +1230,7 @@ pub fn sgx_ql_get_qve_identity<P: Provider>(
                 provider,
                 network,
                 EnclaveID::QVE,
-                collateral_version.clone(),
+                collateral_version,
                 &qve_identity_str,
                 &issuer_chains_str,
                 None,

--- a/rust-crates/libraries/qpl/src/collaterals/helper.rs
+++ b/rust-crates/libraries/qpl/src/collaterals/helper.rs
@@ -1175,7 +1175,7 @@ pub fn sgx_ql_get_qve_identity<P: Provider>(
             provider,
             network,
             EnclaveID::QVE,
-            collateral_version.clone(),
+            collateral_version,
             &qve_identity_str,
             &issuer_chains_str,
             None,

--- a/rust-crates/libraries/qpl/src/collaterals/helper.rs
+++ b/rust-crates/libraries/qpl/src/collaterals/helper.rs
@@ -410,7 +410,7 @@ pub fn sgx_ql_get_quote_config<P: Provider>(
         let req_url = format!(
             "{}/sgx/certification/{}/pckcert",
             pccs_url,
-            collateral_version.clone(),
+            collateral_version,
         );
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -595,7 +595,7 @@ pub fn sgx_ql_get_quote_verification_collateral<P: Provider>(
             pck_crl,
             tcb_info_str,
             enclave_id,
-            collateral_version.clone(),
+            collateral_version,
             enclave_identity_str,
             enclave_identity_issuer_chains_str,
             all_verification_collateral,

--- a/rust-crates/libraries/qpl/src/collaterals/helper.rs
+++ b/rust-crates/libraries/qpl/src/collaterals/helper.rs
@@ -678,7 +678,7 @@ pub fn sgx_ql_get_quote_verification_collateral<P: Provider>(
         let req_url = format!(
             "{}/sgx/certification/{}/tcb?fmspc={}",
             pccs_url,
-            collateral_version.clone(),
+            collateral_version,
             fmspc
         );
         println!("req_url: {:?}", req_url);
@@ -913,7 +913,7 @@ pub fn tdx_ql_get_quote_verification_collateral<P: Provider>(
             pck_crl,
             tcb_info_str,
             enclave_id,
-            collateral_version.clone(),
+            collateral_version,
             enclave_identity_str,
             enclave_identity_issuer_chains_str,
             all_verification_collateral,
@@ -931,7 +931,7 @@ pub fn tdx_ql_get_quote_verification_collateral<P: Provider>(
         let req_url = format!(
             "{}/sgx/certification/{}/pckcrl?ca={}",
             pccs_url,
-            collateral_version.clone(),
+            collateral_version,
             pck_ca.clone()
         );
         let rt = tokio::runtime::Builder::new_current_thread()

--- a/rust-crates/libraries/qpl/src/collaterals/helper.rs
+++ b/rust-crates/libraries/qpl/src/collaterals/helper.rs
@@ -770,7 +770,7 @@ pub fn sgx_ql_get_quote_verification_collateral<P: Provider>(
                 pck_crl.as_str(),
                 tcb_info_str.as_str(),
                 enclave_id,
-                collateral_version.clone(),
+                collateral_version,
                 qe_identity_str.as_str(),
                 enclave_identity_issuer_chains_str.as_str(),
                 all_verification_collateral,
@@ -996,7 +996,7 @@ pub fn tdx_ql_get_quote_verification_collateral<P: Provider>(
         let req_url = format!(
             "{}/tdx/certification/{}/tcb?fmspc={}",
             pccs_url,
-            collateral_version.clone(),
+            collateral_version,
             fmspc
         );
         println!("req_url: {:?}", req_url);


### PR DESCRIPTION
Removed unnecessary .clone() calls in collateral.rs, tcb_info.rs and helper.rs