### PR TITLE
fix(docs): sync comments with code

### DIFF
--- a/go-sdk/packages/godcap/portal.go
+++ b/go-sdk/packages/godcap/portal.go
@@ -303,10 +303,10 @@ func (p *DcapPortal) VerifyAndAttestOnChain(opts *bind.TransactOpts, rawQuote []
 // GenerateZkProof generates zero-knowledge proof for the given quote.
 // Returns error if zkproof client is not initialized or proof generation fails.
 //
-// Note: EnableZkProof() should be called before using this function.
+// Note: WithZkProof() option should be passed to NewDcapPortal before using this function.
 func (p *DcapPortal) GenerateZkProof(ctx context.Context, ty zkdcap.ZkType, quote []byte) (*zkdcap.ZkProof, error) {
 	if p.zkProof == nil {
-		return nil, logex.NewErrorf("DcapPortal should call EnableZkProof() frist")
+		return nil, logex.NewErrorf("WithZkProof() option should be passed to NewDcapPortal first")
 	}
 	parser := parser.NewQuoteParser(quote)
 	collateral, err := zkdcap.NewCollateralFromQuoteParser(ctx, parser, p.pccs)

--- a/rust-crates/libraries/dcap-rs/src/trust_store.rs
+++ b/rust-crates/libraries/dcap-rs/src/trust_store.rs
@@ -37,7 +37,7 @@ impl TrustStore {
     /// * `trusted_certs` - Initial set of trusted root certificates
     ///
     /// # Security Considerations
-    /// * The provided roots establish the foundation of trust
+    /// * The provided trusted_certs establish the foundation of trust
     /// * Current_time must come from a secure source on production systems
     pub fn new(
         current_time: SystemTime,

--- a/rust-crates/libraries/dcap-rs/src/trust_store.rs
+++ b/rust-crates/libraries/dcap-rs/src/trust_store.rs
@@ -34,7 +34,7 @@ impl TrustStore {
     ///
     /// # Parameters
     /// * `current_time` - Time reference for validity checks
-    /// * `roots` - Initial set of trusted root certificates
+    /// * `trusted_certs` - Initial set of trusted root certificates
     ///
     /// # Security Considerations
     /// * The provided roots establish the foundation of trust

--- a/solana/automata-dcap-framework/sdk/src/pccs/pck_dao.rs
+++ b/solana/automata-dcap-framework/sdk/src/pccs/pck_dao.rs
@@ -14,7 +14,7 @@ use crate::CertificateAuthority;
 use crate::shared::{get_certificate_tbs_and_digest, get_issuer_common_name};
 
 /// Intel PCK Certificate Data Access Object Module
-/// This method provides methods to upload and retrieve PCK certificates from the Onchain PCCS program.
+/// This module provides methods to upload and retrieve PCK certificates from the Onchain PCCS program.
 
 impl<S: Clone + Deref<Target = impl Signer>> PccsClient<S> {
 

--- a/solana/automata-dcap-framework/sdk/src/verifier.rs
+++ b/solana/automata-dcap-framework/sdk/src/verifier.rs
@@ -416,14 +416,15 @@ impl<S: Clone + Deref<Target = impl Signer>> VerifierClient<S> {
     /// The chain verification itself is performed off-chain using a ZKVM (Zero-Knowledge Virtual Machine) proof.
     ///
     /// # Parameters:
+    /// - `quote`: The parsed Quote object to verify
     /// - `quote_buffer_pubkey`: The public key of the buffer account containing the quote data
     /// - `verified_output_pubkey`: The public key of the VerifiedOutput account
     /// - `zkvm_verifier_program`: The public key of the ZKVM verifier program
     /// - `zkvm_selector`: The ZKVM selector (currently only supports RiscZero)
-    /// - `proof_bytes`: The SNARK proof bytes for the PCK certificate chain verification
+    /// - `proofs`: The SNARK proof bytes for the PCK certificate chain verification (one proof per certificate)
     ///
     /// # Returns:
-    /// - `Result<Signature>`: The transaction signature for this verification step,
+    /// - `Result<[Signature; 3]>`: The transaction signatures for each certificate verification step,
     ///   or an error if verification fails
     async fn verify_pck_cert_chain(
         &self,
@@ -484,7 +485,6 @@ impl<S: Clone + Deref<Target = impl Signer>> VerifierClient<S> {
     /// Additionally, TDX quotes also check the TCB Status based on the TCB of the TDX module.
     ///
     /// # Parameters
-    /// - `quote`: The parsed Quote object to verify
     /// - `quote_buffer_pubkey`: The public key of the buffer account containing the quote data
     /// - `verified_output_pubkey`: The public key of the VerifiedOutput account
     /// - `quote`: The parsed Quote object to verify


### PR DESCRIPTION
Fixed documentation comments that were out of sync with actual code:
- portal.go: referenced non-existent EnableZkProof() → WithZkProof()
- trust_store.rs: wrong parameter name in docs (roots → trusted_certs)
- pck_dao.rs: "This method" → "This module" for module-level doc
- verifier.rs: wrong parameter names, order and return type in function docs