### PR TITLE
refactor(cli): remove redundant code and optimize network resolution

### DIFF
--- a/rust-crates/apps/cli/src/main.rs
+++ b/rust-crates/apps/cli/src/main.rs
@@ -177,13 +177,6 @@ enum SourceArg {
     All,
 }
 
-#[derive(Copy, Clone, Debug, ValueEnum)]
-enum NetworkFilter {
-    Mainnet,
-    Testnet,
-    All,
-}
-
 impl From<SourceArg> for DataSource {
     fn from(value: SourceArg) -> Self {
         match value {
@@ -360,18 +353,8 @@ async fn main() -> Result<()> {
 
     println!("Using DCAP deployment version: {}", dcap_version);
 
-    // Create provider with smart network resolution and validation
-    let provider = get_provider_from_network_params(&cli, dcap_version).await?;
-
-    // Extract network from provider with the specified deployment version
-    let network = if let Some(network) = &cli.network {
-        Network::by_key(network, Some(dcap_version)).context(format!(
-            "Network '{}' not found for DCAP version {}",
-            network, dcap_version
-        ))?
-    } else {
-        Network::from_provider(&provider, Some(dcap_version)).await?
-    };
+    // Create provider and resolve network in a single operation
+    let (provider, network) = get_provider_and_network(&cli, dcap_version).await?;
 
     // Parse quote from global arguments if provided
     let quote_bytes = match (&cli.quote_path, &cli.quote_hex) {
@@ -386,12 +369,7 @@ async fn main() -> Result<()> {
     match cli.command {
         Commands::Qpl { command } => match command {
             QplCommands::Status { filter } => {
-                let network_filter = match filter {
-                    StatusFilter::Mainnet => NetworkFilter::Mainnet,
-                    StatusFilter::Testnet => NetworkFilter::Testnet,
-                    StatusFilter::All => NetworkFilter::All,
-                };
-                handle_collateral_status(network_filter, dcap_version).await?
+                handle_collateral_status(filter, dcap_version).await?
             }
             QplCommands::Check { all_networks } => {
                 if let Some(filter) = all_networks {
@@ -675,10 +653,12 @@ async fn handle_collateral_status(filter: NetworkFilter, version: Version) -> Re
     Ok(())
 }
 
-/// Creates a provider from CLI arguments with smart network resolution and validation
-async fn get_provider_from_network_params(cli: &Cli, version: Version) -> Result<impl Provider> {
-    use Network;
-
+/// Creates a provider from CLI arguments with smart network resolution and validation.
+/// Returns both the provider and the resolved network to avoid duplicate resolution.
+async fn get_provider_and_network(
+    cli: &Cli,
+    version: Version,
+) -> Result<(impl Provider, &'static Network)> {
     match (&cli.network, &cli.rpc_url) {
         // Case A: Both --network and --rpc-url provided - validate chain_id
         (Some(network_key), Some(custom_rpc)) => {

--- a/rust-crates/apps/cli/src/main.rs
+++ b/rust-crates/apps/cli/src/main.rs
@@ -703,7 +703,7 @@ async fn get_provider_from_network_params(cli: &Cli, version: Version) -> Result
                 queried_chain_id
             );
 
-            Ok(provider)
+            Ok((provider, network))
         }
 
         // Case B: Only --rpc-url provided - auto-detect network
@@ -725,7 +725,7 @@ async fn get_provider_from_network_params(cli: &Cli, version: Version) -> Result
                 network.chain_id
             );
 
-            Ok(provider)
+            Ok((provider, network))
         }
 
         // Case C: Only --network provided
@@ -741,7 +741,7 @@ async fn get_provider_from_network_params(cli: &Cli, version: Version) -> Result
                 network.chain_id
             );
 
-            Ok(provider)
+            Ok((provider, network))
         }
 
         // Case D: Neither provided - use default network
@@ -757,7 +757,7 @@ async fn get_provider_from_network_params(cli: &Cli, version: Version) -> Result
                 network.chain_id
             );
 
-            Ok(provider)
+            Ok((provider, network))
         }
     }
 }

--- a/rust-crates/apps/cli/src/main.rs
+++ b/rust-crates/apps/cli/src/main.rs
@@ -164,7 +164,7 @@ enum VerifyCommands {
 }
 
 #[derive(Copy, Clone, Debug, ValueEnum)]
-enum StatusFilter {
+enum NetworkFilter {
     Mainnet,
     Testnet,
     All,

--- a/rust-crates/apps/cli/src/main.rs
+++ b/rust-crates/apps/cli/src/main.rs
@@ -289,7 +289,7 @@ enum QplCommands {
     Status {
         /// Filter networks by type
         #[arg(long, value_enum, default_value = "all")]
-        filter: StatusFilter,
+        filter: NetworkFilter,
     },
     /// Inspect which collaterals are missing for a quote
     Check {

--- a/rust-crates/libraries/utils/src/version.rs
+++ b/rust-crates/libraries/utils/src/version.rs
@@ -14,9 +14,7 @@ pub enum Version {
 }
 impl Version {
     #[doc = r" Get all supported versions"]
-    pub fn all() -> Vec<Version> {
-        vec![Version::V1_0, Version::V1_1]
-    }
+    pub fn all() -> Vec<Version> { vec![Version::V1_0, Version::V1_1] }
     #[doc = r#" Get the version string (e.g., "v1.0")"#]
     pub fn as_str(&self) -> &'static str {
         match self {
@@ -40,9 +38,7 @@ impl Version {
     }
 }
 impl fmt::Display for Version {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.as_str())
-    }
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { write!(f, "{}", self.as_str()) }
 }
 impl FromStr for Version {
     type Err = anyhow::Error;


### PR DESCRIPTION
1. Merge identical StatusFilter and NetworkFilter enums into single NetworkFilter
2. Remove redundant `use Network` import (already imported globally)
3. Return network from get_provider_and_network() to avoid resolving it twice