### PR TITLE
fix: prevent QE convergence from overwriting relaunch status in V5Quo…

### DIFF
--- a/evm/contracts/verifiers/V5QuoteVerifier.sol
+++ b/evm/contracts/verifiers/V5QuoteVerifier.sol
@@ -96,6 +96,12 @@ contract V5QuoteVerifier is TdxQuoteBase {
 
             tdxStatus = convergeTcbStatusWithTdxModuleStatus(tdxStatus, tdxModuleStatus);
 
+            // QE convergence must happen before the relaunch check,
+            // so that relaunch status (if set) is the final output.
+            // This is safe because relaunch conditions require QE to NOT be OutOfDate,
+            // meaning QE convergence is a no-op whenever relaunch is triggered.
+            tcbStatus = uint8(convergeTcbStatusWithQeTcbStatus(result.qeTcbStatus, tdxStatus));
+
             if (quoteBodySize == TD_REPORT15_LENGTH) {
                 // Relaunch check (TD 1.5 only)
                 bool relaunchAdvised;
@@ -110,8 +116,6 @@ contract V5QuoteVerifier is TdxQuoteBase {
                         configurationNeeded ? TCB_TD_RELAUNCH_ADVISED_CONFIGURATION_NEEDED : TCB_TD_RELAUNCH_ADVISED;
                 }
             }
-
-            tcbStatus = uint8(convergeTcbStatusWithQeTcbStatus(result.qeTcbStatus, tdxStatus));
         }
 
         Output memory output = Output({


### PR DESCRIPTION
## Summary
  - Fix a bug in `V5QuoteVerifier.verifyQuote` where the TD 1.5 relaunch advisory status
    (`TCB_TD_RELAUNCH_ADVISED` / `TCB_TD_RELAUNCH_ADVISED_CONFIGURATION_NEEDED`) was always overwritten by the subsequent `convergeTcbStatusWithQeTcbStatus` call on line 114, which used `tdxStatus` (pre-relaunch) instead of `tcbStatus` (post-relaunch)

  ## Problem
  In the TDX branch of `verifyQuote`, the execution order was:

  1. Relaunch check → sets `tcbStatus` to relaunch value (8 or 9)
  2. QE convergence → unconditionally overwrites `tcbStatus` using `tdxStatus` as input

  This meant the relaunch status was computed but never reflected in the final output. Quotes that should return `TCB_TD_RELAUNCH_ADVISED` (8) instead returned `TCB_OUT_OF_DATE` (4) or `TCB_OUT_OF_DATE_CONFIGURATION_NEEDED` (5).

  The Rust reference implementation in `dcap-rs/src/lib.rs:148-178` correctly preserves the relaunch status by applying QE convergence to `tcb_status` (which already contains the relaunch value) rather than the raw `tdx_status`.

  ## Fix
  Move `convergeTcbStatusWithQeTcbStatus` **before** the relaunch check, so the relaunch status becomes the final output when applicable.

  This is semantically safe because `_checkForRelaunch` requires `qeTcbStatus != SGX_ENCLAVE_REPORT_ISVSVN_OUT_OF_DATE` as a precondition, meaning QE convergence is always a no-op when relaunch is triggered.

  ## Test plan

  - [x] Verify existing V5 quote verification tests still pass
  - [ ] Add a test case with a TD 1.5 quote that triggers relaunch conditions and assert the output `tcbStatus` is `TCB_TD_RELAUNCH_ADVISED` (8) or `TCB_TD_RELAUNCH_ADVISED_CONFIGURATION_NEEDED` (9)