### PR TITLE
Fix missing statusFound check in V5QuoteVerifier SGX path

### DIFF
--- a/evm/contracts/verifiers/V5QuoteVerifier.sol
+++ b/evm/contracts/verifiers/V5QuoteVerifier.sol
@@ -56,7 +56,7 @@ contract V5QuoteVerifier is TdxQuoteBase {
                     break;
                 }
             }
-            if (sgxStatus == TCBStatus.TCB_REVOKED) {
+            if (!statusFound || sgxStatus == TCBStatus.TCB_REVOKED) {
                 return (false, bytes(TCBR));
             }
             sgxStatus = convergeTcbStatusWithQeTcbStatus(result.qeTcbStatus, sgxStatus);


### PR DESCRIPTION
## Summary
  - Add `!statusFound` check to V5QuoteVerifier's SGX branch, consistent with V3QuoteVerifier (line 51) and V4QuoteVerifier (line 119)
  - Without this fix, an unmatched TCB level causes `tcbLevelSelected` to remain `type(uint256).max`, resulting in an opaque array out-of-bounds revert

  ## Test plan
  - [x] Existing `forge test` suite passes (9/9)