### PR TITLE
Fix TCB_REVOKED returning success=true in V3/V4 SGX path and incomple…

### DIFF
--- a/evm/contracts/bases/QuoteVerifierBase.sol
+++ b/evm/contracts/bases/QuoteVerifierBase.sol
@@ -372,9 +372,11 @@ abstract contract QuoteVerifierBase is IQuoteVerifier, EnclaveIdBase, X509ChainB
         bytes32 expectedProcessorCrlHash;
         if (platformSuccess) {
             expectedPlatformCrlHash = abi.decode(platformRet, (bytes32));
-        } else if (processorSuccess) {
+        }
+        if (processorSuccess) {
             expectedProcessorCrlHash = abi.decode(processorRet, (bytes32));
-        } else {
+        }
+        if (!platformSuccess && !processorSuccess) {
             // Both Processor and Platform PCKs not found
             return (false, bytes(PCKCRLM));
         }

--- a/evm/contracts/verifiers/V3QuoteVerifier.sol
+++ b/evm/contracts/verifiers/V3QuoteVerifier.sol
@@ -46,7 +46,7 @@ contract V3QuoteVerifier is QuoteVerifierBase, TCBInfoV2Base {
             }
         }
         if (!statusFound || tcbStatus == TCBStatus.TCB_REVOKED) {
-            return (statusFound, bytes(TCBR));
+            return (false, bytes(TCBR));
         }
 
         tcbStatus = convergeTcbStatusWithQeTcbStatus(result.qeTcbStatus, tcbStatus);

--- a/evm/contracts/verifiers/V4QuoteVerifier.sol
+++ b/evm/contracts/verifiers/V4QuoteVerifier.sol
@@ -113,7 +113,7 @@ contract V4QuoteVerifier is TdxQuoteBase {
             }
         }
         if (!statusFound || tcbStatus == TCBStatus.TCB_REVOKED) {
-            return (statusFound, bytes(TCBR));
+            return (false, bytes(TCBR));
         }
 
         tcbStatus = convergeTcbStatusWithQeTcbStatus(result.qeTcbStatus, tcbStatus);


### PR DESCRIPTION
## Summary
  - Fix V3/V4 QuoteVerifier SGX path returning `success=true` when `tcbStatus == TCB_REVOKED`, aligning with V5 and V4-TDX behavior
  - Fix `checkCollateralHashes` in QuoteVerifierBase using `if/else if` for PCK CRL hash decoding, which caused valid Processor CA quotes to be rejected when both Platform and Processor CRLs exist on-chain

  ## Test plan
  - [x] Run existing forge tests to confirm no regressions