### PR TITLE
refactor: remove useless transmute and simplify turbofish

### DIFF
--- a/rust-crates/libraries/qpl/src/types.rs
+++ b/rust-crates/libraries/qpl/src/types.rs
@@ -460,21 +460,18 @@ impl SgxQlQveCollateral {
 
     pub fn print(&self) {
         println!("[Automata DCAP QPL] ---SgxQlQveCollateral---");
-        #[allow(clippy::useless_transmute)]
+        let tee_type = self.tee_type;
         let version = unsafe {
-            if self.tee_type == 0x0 {
-                format!("{}", std::mem::transmute::<u32, u32>(self.version.version))
+            if tee_type == 0x0 {
+                let v = self.version.version;
+                v.to_string()
             } else {
-                format!(
-                    "major {}, minor {}, ",
-                    std::mem::transmute::<u16, u16>(self.version.versions.major_version),
-                    std::mem::transmute::<u16, u16>(self.version.versions.minor_version),
-                )
+                let major = self.version.versions.major_version;
+                let minor = self.version.versions.minor_version;
+                format!("major {}, minor {}, ", major, minor)
             }
         };
         println!("[Automata DCAP QPL]  version: {:?}", version);
-        #[allow(clippy::useless_transmute)]
-        let tee_type = unsafe { std::mem::transmute::<u32, u32>(self.tee_type) };
         println!("[Automata DCAP QPL]  tee_type: {:?}", tee_type);
 
         println!(

--- a/solana/automata-dcap-framework/sdk/src/verifier.rs
+++ b/solana/automata-dcap-framework/sdk/src/verifier.rs
@@ -610,19 +610,13 @@ impl<S: Clone + Deref<Target = impl Signer>> VerifierClient<S> {
         let quote_body = match verified_output_account.tee_type {
             SGX_TEE_TYPE => QuoteBody::SgxQuoteBody(
                 EnclaveReportBody::try_from(
-                    TryInto::<[u8; std::mem::size_of::<EnclaveReportBody>()]>::try_into(
-                        verified_output_account.quote_body.clone(),
-                    )
-                    .unwrap(),
+                    verified_output_account.quote_body.clone().try_into().unwrap(),
                 )
                 .unwrap(),
             ),
             TDX_TEE_TYPE => QuoteBody::Td10QuoteBody(
                 Td10ReportBody::try_from(
-                    TryInto::<[u8; std::mem::size_of::<Td10ReportBody>()]>::try_into(
-                        verified_output_account.quote_body.clone(),
-                    )
-                    .unwrap(),
+                    verified_output_account.quote_body.clone().try_into().unwrap(),
                 )
                 .unwrap(),
             ),


### PR DESCRIPTION
- Remove `transmute::<u32, u32>` and `transmute::<u16, u16>` in qpl/types.rs (no-op conversions)
- Remove unnecessary `#[allow(clippy::useless_transmute)]` attributes
- Replace `format!("{}", v)` with `v.to_string()`
- Simplify `TryInto::<[u8; size_of::<T>()]>::try_into(x)` to `x.try_into()` in verifier.rs (type inferred from context)