### PR TITLE
docs: fix documentation mismatches with actual code

### DIFF
--- a/evm/docs/OnChainQuoteAttestation.md
+++ b/evm/docs/OnChainQuoteAttestation.md
@@ -1,6 +1,6 @@
 # `AutomataDcapAttestation` On Chain Verification Workflow
 
-This document provides a high-level overview of the full on-chain verification workflow, covering V3 SGX, V4 SGX and TDX quotes. 
+This document provides a high-level overview of the full on-chain verification workflow, covering V3 SGX, V4 SGX and TDX, and V5 SGX and TDX quotes. 
 
 We advise reading through the code and refer to [Intel's official documentation](https://download.01.org/intel-sgx/sgx-dcap/1.22/linux/docs/) for a deep dive into the technical details about DCAP Quote Verification.
 
@@ -61,6 +61,7 @@ The on-chain workflow is designed to:
 - **Forwarding:** Based on the quote version, the contract routes the verification:
   - **V3 SGX Quotes:** Processed by `V3QuoteVerifier`.
   - **V4 SGX and TDX Quotes:** Processed by `V4QuoteVerifier`.
+  - **V5 SGX and TDX Quotes:** Processed by `V5QuoteVerifier`.
 
 ### 3.2. Verification Process
 

--- a/rust-crates/README.md
+++ b/rust-crates/README.md
@@ -21,7 +21,7 @@
 This workspace provides a comprehensive toolkit for Intel DCAP (Data Center Attestation Primitives) quote verification and attestation, featuring both library components for integration and a CLI tool for testing and examples.
 
 **For Developers:** The project offers several Rust libraries that can be integrated directly into your applications:
-- **dcap-rs**: Pure Rust implementation of Intel's DCAP Quote Verification Library (QVL), supporting V3 SGX and V4 TDX/SGX quotes
+- **dcap-rs**: Pure Rust implementation of Intel's DCAP Quote Verification Library (QVL), supporting V3 SGX, V4 TDX/SGX, and V5 TDX/SGX quotes
 - **pccs-reader**: Reader library for decoding collaterals from Automata Onchain PCCS and detecting missing collaterals
 - **automata-dcap-qpl**: Quote Provider Library wrapper for fetching collaterals from various sources
 - **automata-dcap-zkvm**: zkVM proof generation libraries with support for RISC Zero, SP1, and Pico platforms
@@ -51,16 +51,16 @@ This repository uses a **unified Rust workspace** with smart defaults:
 - `apps/cli`: Unified `automata-dcap` CLI (quote verification, collateral detection, network management, zkVM proof generation)
 
 **Core Libraries:**
-- `crates/dcap-rs`: Pure Rust implementation of Intel's DCAP Quote Verification Library (QVL) for V3 SGX and V4 TDX/SGX quotes
-- `crates/verifier`: High-level verification APIs that orchestrate quote verification workflows for both onchain and zkVM-based attestation
-- `crates/zkvm`: zkVM proof generation framework with unified trait-based architecture supporting RISC Zero, SP1, and Pico platforms
+- `libraries/dcap-rs`: Pure Rust implementation of Intel's DCAP Quote Verification Library (QVL) for V3 SGX, V4 TDX/SGX, and V5 TDX/SGX quotes
+- `libraries/verifier`: High-level verification APIs that orchestrate quote verification workflows for both onchain and zkVM-based attestation
+- `libraries/zkvm`: zkVM proof generation framework with unified trait-based architecture supporting RISC Zero, SP1, and Pico platforms
 
 **Support Libraries:**
-- `crates/pccs-reader`: Reader for decoding collaterals from Automata Onchain PCCS and detecting missing collaterals for a given quote
-- `crates/qpl`: Quote Provider Library (QPL) wrapper for fetching collaterals from Intel PCS, local PCCS, or Automata Onchain PCCS
-- `crates/network-registry`: Network configuration registry managing deployment addresses and contract ABIs across multiple chains and versions
-- `crates/utils`: Common utilities including version-aware type generation and helper functions shared across the workspace
-- `crates/bindings`: Auto-generated Rust bindings for EVM contract interfaces (regenerated via build script)
+- `libraries/pccs-reader`: Reader for decoding collaterals from Automata Onchain PCCS and detecting missing collaterals for a given quote
+- `libraries/qpl`: Quote Provider Library (QPL) wrapper for fetching collaterals from Intel PCS, local PCCS, or Automata Onchain PCCS
+- `libraries/network-registry`: Network configuration registry managing deployment addresses and contract ABIs across multiple chains and versions
+- `libraries/utils`: Common utilities including version-aware type generation and helper functions shared across the workspace
+- `libraries/bindings`: Auto-generated Rust bindings for EVM contract interfaces (regenerated via build script)
 
 **Contract Interfaces:**
 - `contracts/`: Solidity contract interfaces for Automata Onchain PCCS and Automata DCAP Attestation to generate Rust bindings
@@ -73,7 +73,7 @@ Whenever the Solidity ABI changes, regenerate the bindings from the repository r
 AUTOMATA_UPDATE_BINDINGS=1 cargo build -p automata-dcap-evm-bindings
 ```
 
-This runs `forge build` and writes fresh bindings into `crates/dcap-evm-bindings/src/bindings`.
+This runs `forge build` and writes fresh bindings into `libraries/bindings/src/bindings`.
 To enforce drift checks locally or in CI, run:
 
 ```bash

--- a/solana/automata-dcap-framework/README.md
+++ b/solana/automata-dcap-framework/README.md
@@ -18,7 +18,7 @@ The Solana DCAP Attestation Framework provides a comprehensive solution for veri
         - ``verify_dcap_quote_integrity()``
         - ``verify_dcap_quote_isv_signature()``
         - ``verify_dcap_quote_enclave_source()``
-        - ``verify_pck_cert_chain()``
+        - ``verify_pck_cert_chain_zk()``
         - ``verify_dcap_quote_tcb_status()``
     - Final verified output is stored in a VerifiedOutput account
 4. Security Components:
@@ -87,7 +87,7 @@ sequenceDiagram
     DCAP->>Output: Sets verified_output.qe_tcb_status
     Note over Output: Sets the QE TCB Status.
 
-    SDK->>DCAP: (6) verify_pck_cert_chain()
+    SDK->>DCAP: (6) verify_pck_cert_chain_zk()
 
     Note over SDK: Verifies the root of trust in the provided PCK Certificate chain.
 
@@ -104,7 +104,7 @@ sequenceDiagram
     DCAP->>PCCS: Requests to fetch TcbInfo data
     PCCS->>DCAP: Returns TcbInfo data
     DCAP->>Output: Sets verified_output.fmspc_tcb_status, tdx_module_tcb_status and advisory_ids
-    Note over Output: Populates the FMSPC field. tdx_module_tcb_status is only applicable for TDX quotes. Advisory IDs are only available for V4 quotes.
+    Note over Output: Populates the FMSPC field. tdx_module_tcb_status is only applicable for TDX quotes. Advisory IDs are available for V4 and V5 quotes.
 
     SDK->>Output: Fetches VerifiedOutput account data
     Output->>SDK: Returns VerifiedOutput data


### PR DESCRIPTION

- Solana README: `verify_pck_cert_chain()` -> `verify_pck_cert_chain_zk()` (function doesn't exist)
- rust-crates README: wrong paths `crates/` -> `libraries/`
- rust-crates README: missing V5 quote support in dcap-rs description
- EVM OnChainQuoteAttestation.md: missing V5QuoteVerifier documentation
- Solana README: Advisory IDs note now includes V5 quotes