### PR TITLE
Add PCCS router collateral versioning wrappers and tests

### DIFF
--- a/evm/contracts/PCCSRouter.sol
+++ b/evm/contracts/PCCSRouter.sol
@@ -19,6 +19,15 @@ interface IVersionedDao {
     function TCB_EVALUATION_NUMBER() external view returns (uint32);
 }
 
+interface ICollateralVersioning {
+    function collateralVersion(bytes32 key) external view returns (uint256 version);
+
+    function hasChanged(bytes32 key, uint256 sinceVersion)
+        external
+        view
+        returns (bool changed, uint256 currentVersion);
+}
+
 /**
  * @title Automata PCCS Router
  * @dev contracts wanting to read collaterals from On-Chain PCCS
@@ -241,6 +250,98 @@ contract PCCSRouter is IPCCSRouter, Ownable {
         returns (bytes32 contentHash)
     {
         contentHash = _getQeIdentityContentHash(id, pcsApiVersion, tcbEval, block.timestamp);
+    }
+
+    function getFmspcTcbVersion(TcbId id, bytes6 fmspc, uint32 version, uint32 tcbEval)
+        external
+        view
+        override
+        onlyAuthorized
+        returns (uint256 ver)
+    {
+        address versionedDao = fmspcTcbDaoVersionedAddr[tcbEval];
+        if (versionedDao == address(0)) {
+            revert FmspcTcbExpiredOrNotFound(id, version);
+        }
+
+        FmspcTcbDao versionedTcbDao = FmspcTcbDao(versionedDao);
+        bytes32 versionedKey = versionedTcbDao.FMSPC_TCB_KEY(uint8(id), fmspc, version);
+        ver = ICollateralVersioning(versionedDao).collateralVersion(versionedKey);
+    }
+
+    function getQeIdentityVersion(EnclaveId id, uint256 pcsApiVersion, uint32 tcbEval)
+        external
+        view
+        override
+        onlyAuthorized
+        returns (uint256 ver)
+    {
+        address versionedDao = qeIdDaoVersionedAddr[tcbEval];
+        if (versionedDao == address(0)) {
+            revert QEIdentityExpiredOrNotFound(id, pcsApiVersion);
+        }
+
+        EnclaveIdentityDao versionedEnclaveIdDao = EnclaveIdentityDao(versionedDao);
+        bytes32 versionedKey = versionedEnclaveIdDao.ENCLAVE_ID_KEY(uint256(id), pcsApiVersion);
+        ver = ICollateralVersioning(versionedDao).collateralVersion(versionedKey);
+    }
+
+    function getPcsCollateralVersion(CA ca, bool isCrl)
+        external
+        view
+        override
+        onlyAuthorized
+        returns (uint256 ver)
+    {
+        PcsDao pcsDao = PcsDao(pcsDaoAddr);
+        bytes32 key = pcsDao.PCS_KEY(ca, isCrl);
+        ver = ICollateralVersioning(pcsDaoAddr).collateralVersion(key);
+    }
+
+    function hasFmspcTcbChanged(TcbId id, bytes6 fmspc, uint32 version, uint32 tcbEval, uint256 sinceVersion)
+        external
+        view
+        override
+        onlyAuthorized
+        returns (bool changed, uint256 currentVersion)
+    {
+        address versionedDao = fmspcTcbDaoVersionedAddr[tcbEval];
+        if (versionedDao == address(0)) {
+            revert FmspcTcbExpiredOrNotFound(id, version);
+        }
+
+        FmspcTcbDao versionedTcbDao = FmspcTcbDao(versionedDao);
+        bytes32 versionedKey = versionedTcbDao.FMSPC_TCB_KEY(uint8(id), fmspc, version);
+        (changed, currentVersion) = ICollateralVersioning(versionedDao).hasChanged(versionedKey, sinceVersion);
+    }
+
+    function hasQeIdentityChanged(EnclaveId id, uint256 pcsApiVersion, uint32 tcbEval, uint256 sinceVersion)
+        external
+        view
+        override
+        onlyAuthorized
+        returns (bool changed, uint256 currentVersion)
+    {
+        address versionedDao = qeIdDaoVersionedAddr[tcbEval];
+        if (versionedDao == address(0)) {
+            revert QEIdentityExpiredOrNotFound(id, pcsApiVersion);
+        }
+
+        EnclaveIdentityDao versionedEnclaveIdDao = EnclaveIdentityDao(versionedDao);
+        bytes32 versionedKey = versionedEnclaveIdDao.ENCLAVE_ID_KEY(uint256(id), pcsApiVersion);
+        (changed, currentVersion) = ICollateralVersioning(versionedDao).hasChanged(versionedKey, sinceVersion);
+    }
+
+    function hasPcsCollateralChanged(CA ca, bool isCrl, uint256 sinceVersion)
+        external
+        view
+        override
+        onlyAuthorized
+        returns (bool changed, uint256 currentVersion)
+    {
+        PcsDao pcsDao = PcsDao(pcsDaoAddr);
+        bytes32 key = pcsDao.PCS_KEY(ca, isCrl);
+        (changed, currentVersion) = ICollateralVersioning(pcsDaoAddr).hasChanged(key, sinceVersion);
     }
 
     function getQeIdentityContentHashWithTimestamp(

--- a/evm/contracts/interfaces/IPCCSRouter.sol
+++ b/evm/contracts/interfaces/IPCCSRouter.sol
@@ -49,6 +49,33 @@ interface IPCCSRouter {
 
     function getQeIdentityContentHash(EnclaveId id, uint256 pcsApiVersion, uint32 tcbEval) external view returns (bytes32);
 
+    function getFmspcTcbVersion(TcbId id, bytes6 fmspc, uint32 version, uint32 tcbEval)
+        external
+        view
+        returns (uint256);
+
+    function getQeIdentityVersion(EnclaveId id, uint256 pcsApiVersion, uint32 tcbEval)
+        external
+        view
+        returns (uint256);
+
+    function getPcsCollateralVersion(CA ca, bool isCrl) external view returns (uint256);
+
+    function hasFmspcTcbChanged(TcbId id, bytes6 fmspc, uint32 version, uint32 tcbEval, uint256 sinceVersion)
+        external
+        view
+        returns (bool changed, uint256 currentVersion);
+
+    function hasQeIdentityChanged(EnclaveId id, uint256 pcsApiVersion, uint32 tcbEval, uint256 sinceVersion)
+        external
+        view
+        returns (bool changed, uint256 currentVersion);
+
+    function hasPcsCollateralChanged(CA ca, bool isCrl, uint256 sinceVersion)
+        external
+        view
+        returns (bool changed, uint256 currentVersion);
+
     function getFmspcTcbV2(bytes6 fmspc, uint32 tcbEval) external view returns (TCBLevelsObj[] memory);
 
     function getFmspcTcbV3(TcbId id, bytes6 fmspc, uint32 tcbEval)

--- a/evm/forge-test/PCCSRouterVersioningTest.t.sol
+++ b/evm/forge-test/PCCSRouterVersioningTest.t.sol
@@ -9,6 +9,7 @@ import {TcbId} from "@automata-network/on-chain-pccs/helpers/FmspcTcbHelper.sol"
 
 contract PCCSRouterVersioningTest is PCCSSetupBase {
     PCCSRouter pccsRouter;
+    bytes6 constant FMSPC_TDX = bytes6(uint48(0x00806f050000));
 
     function setUp() public override {
         vm.warp(1749095100);
@@ -63,5 +64,93 @@ contract PCCSRouterVersioningTest is PCCSSetupBase {
         assertEq(tcbVersion, 1);
         assertFalse(tcbChangedFromCurrent);
         assertEq(tcbCurrentVersion, 1);
+    }
+
+    function testNewVersionApisRespectCallerRestriction() public {
+        uint32 tcbEval = fmspcTcbDao.TCB_EVALUATION_NUMBER();
+
+        vm.prank(admin);
+        pccsRouter.enableCallerRestriction();
+
+        vm.expectRevert(PCCSRouter.Forbidden.selector);
+        pccsRouter.getQeIdentityVersion(EnclaveId.TD_QE, 4, tcbEval);
+
+        vm.prank(admin);
+        pccsRouter.setAuthorized(address(this), true);
+
+        assertEq(pccsRouter.getQeIdentityVersion(EnclaveId.TD_QE, 4, tcbEval), 1);
+        assertEq(pccsRouter.getFmspcTcbVersion(TcbId.TDX, FMSPC_TDX, 3, tcbEval), 1);
+        assertEq(pccsRouter.getPcsCollateralVersion(CA.ROOT, false), 1);
+    }
+
+    function testNewVersionApisRevertWhenVersionedDaoNotConfigured() public {
+        uint32 unsetEval = 9999;
+
+        vm.expectRevert(
+            abi.encodeWithSelector(PCCSRouter.QEIdentityExpiredOrNotFound.selector, EnclaveId.TD_QE, uint256(4))
+        );
+        pccsRouter.getQeIdentityVersion(EnclaveId.TD_QE, 4, unsetEval);
+
+        vm.expectRevert(abi.encodeWithSelector(PCCSRouter.FmspcTcbExpiredOrNotFound.selector, TcbId.TDX, uint256(3)));
+        pccsRouter.getFmspcTcbVersion(TcbId.TDX, FMSPC_TDX, 3, unsetEval);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(PCCSRouter.QEIdentityExpiredOrNotFound.selector, EnclaveId.TD_QE, uint256(4))
+        );
+        pccsRouter.hasQeIdentityChanged(EnclaveId.TD_QE, 4, unsetEval, 0);
+
+        vm.expectRevert(abi.encodeWithSelector(PCCSRouter.FmspcTcbExpiredOrNotFound.selector, TcbId.TDX, uint256(3)));
+        pccsRouter.hasFmspcTcbChanged(TcbId.TDX, FMSPC_TDX, 3, unsetEval, 0);
+    }
+
+    function testVersionIncrementsOnSecondValidUpsertForAllCollateralTypes() public {
+        uint32 tcbEval = fmspcTcbDao.TCB_EVALUATION_NUMBER();
+
+        // PCS CRL versioning: insert 0825 CRL while it is valid, then replace with newer 1025 CRL.
+        vm.warp(1755302400); // 2025-08-16T00:00:00Z
+        vm.startPrank(admin);
+        bytes memory oldPlatformCrl = vm.readFileBinary(string.concat(vm.projectRoot(), "/forge-test/assets/0825/platform_crl.der"));
+        pcsDao.upsertPckCrl(CA.PLATFORM, oldPlatformCrl);
+        assertEq(pccsRouter.getPcsCollateralVersion(CA.PLATFORM, true), 1);
+
+        // QE Identity and TCB fixtures in setUp are from 0625; replace with newer 1025 fixtures.
+        vm.warp(1761004800); // 2025-10-21T00:00:00Z
+        qeIdDaoUpsert(4, "/forge-test/assets/1025/identity.json");
+        fmspcTcbDaoUpsert("/forge-test/assets/1025/tcb_info.json");
+
+        bytes memory newPlatformCrl = vm.readFileBinary(string.concat(vm.projectRoot(), "/forge-test/assets/1025/pck_crl.der"));
+        pcsDao.upsertPckCrl(CA.PLATFORM, newPlatformCrl);
+        vm.stopPrank();
+
+        assertEq(pccsRouter.getQeIdentityVersion(EnclaveId.TD_QE, 4, tcbEval), 2);
+        assertEq(pccsRouter.getFmspcTcbVersion(TcbId.TDX, FMSPC_TDX, 3, tcbEval), 2);
+        assertEq(pccsRouter.getPcsCollateralVersion(CA.PLATFORM, true), 2);
+    }
+
+    function testE2EHasChangedFlipsAfterRealCollateralUpdate() public {
+        uint32 tcbEval = fmspcTcbDao.TCB_EVALUATION_NUMBER();
+
+        // No updates since setUp baseline insertions.
+        (bool qeChangedBefore, uint256 qeVersionBefore) = pccsRouter.hasQeIdentityChanged(EnclaveId.TD_QE, 4, tcbEval, 1);
+        (bool tcbChangedBefore, uint256 tcbVersionBefore) =
+            pccsRouter.hasFmspcTcbChanged(TcbId.TDX, FMSPC_TDX, 3, tcbEval, 1);
+        assertFalse(qeChangedBefore);
+        assertEq(qeVersionBefore, 1);
+        assertFalse(tcbChangedBefore);
+        assertEq(tcbVersionBefore, 1);
+
+        vm.warp(1761004800); // 2025-10-21T00:00:00Z
+        vm.startPrank(admin);
+        qeIdDaoUpsert(4, "/forge-test/assets/1025/identity.json");
+        fmspcTcbDaoUpsert("/forge-test/assets/1025/tcb_info.json");
+        vm.stopPrank();
+
+        (bool qeChangedAfter, uint256 qeVersionAfter) = pccsRouter.hasQeIdentityChanged(EnclaveId.TD_QE, 4, tcbEval, 1);
+        (bool tcbChangedAfter, uint256 tcbVersionAfter) =
+            pccsRouter.hasFmspcTcbChanged(TcbId.TDX, FMSPC_TDX, 3, tcbEval, 1);
+        assertTrue(qeChangedAfter);
+        assertEq(qeVersionAfter, 2);
+        assertTrue(tcbChangedAfter);
+        assertEq(tcbVersionAfter, 2);
     }
 }

--- a/evm/forge-test/PCCSRouterVersioningTest.t.sol
+++ b/evm/forge-test/PCCSRouterVersioningTest.t.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "./utils/PCCSSetupBase.sol";
+
+import {CA} from "@automata-network/on-chain-pccs/Common.sol";
+import {EnclaveId} from "@automata-network/on-chain-pccs/helpers/EnclaveIdentityHelper.sol";
+import {TcbId} from "@automata-network/on-chain-pccs/helpers/FmspcTcbHelper.sol";
+
+contract PCCSRouterVersioningTest is PCCSSetupBase {
+    PCCSRouter pccsRouter;
+
+    function setUp() public override {
+        vm.warp(1749095100);
+        super.setUp();
+
+        vm.startPrank(admin);
+        pccsRouter = setupPccsRouter(admin);
+        pcsDaoUpserts();
+
+        enclaveIdDao.grantRoles(admin, enclaveIdDao.ATTESTER_ROLE());
+        fmspcTcbDao.grantRoles(admin, fmspcTcbDao.ATTESTER_ROLE());
+
+        qeIdDaoUpsert(4, "/forge-test/assets/0625/qe_td.json");
+        fmspcTcbDaoUpsert("/forge-test/assets/0625/tcbinfov3_00806f050000.json");
+        vm.stopPrank();
+    }
+
+    function testGetCollateralVersions() public view {
+        uint32 tcbEval = fmspcTcbDao.TCB_EVALUATION_NUMBER();
+
+        assertEq(pccsRouter.getPcsCollateralVersion(CA.ROOT, false), 1);
+        assertEq(pccsRouter.getPcsCollateralVersion(CA.ROOT, true), 1);
+        assertEq(pccsRouter.getPcsCollateralVersion(CA.PLATFORM, false), 1);
+        assertEq(pccsRouter.getQeIdentityVersion(EnclaveId.TD_QE, 4, tcbEval), 1);
+        assertEq(pccsRouter.getFmspcTcbVersion(TcbId.TDX, bytes6(uint48(0x00806f050000)), 3, tcbEval), 1);
+    }
+
+    function testHasCollateralChanged() public view {
+        uint32 tcbEval = fmspcTcbDao.TCB_EVALUATION_NUMBER();
+        (bool rootCertChanged, uint256 rootCertVersion) = pccsRouter.hasPcsCollateralChanged(CA.ROOT, false, 0);
+        (bool rootCertChangedFromCurrent, uint256 rootCertCurrentVersion) =
+            pccsRouter.hasPcsCollateralChanged(CA.ROOT, false, 1);
+        (bool qeChanged, uint256 qeVersion) = pccsRouter.hasQeIdentityChanged(EnclaveId.TD_QE, 4, tcbEval, 0);
+        (bool qeChangedFromCurrent, uint256 qeCurrentVersion) =
+            pccsRouter.hasQeIdentityChanged(EnclaveId.TD_QE, 4, tcbEval, 1);
+        (bool tcbChanged, uint256 tcbVersion) =
+            pccsRouter.hasFmspcTcbChanged(TcbId.TDX, bytes6(uint48(0x00806f050000)), 3, tcbEval, 0);
+        (bool tcbChangedFromCurrent, uint256 tcbCurrentVersion) =
+            pccsRouter.hasFmspcTcbChanged(TcbId.TDX, bytes6(uint48(0x00806f050000)), 3, tcbEval, 1);
+
+        assertTrue(rootCertChanged);
+        assertEq(rootCertVersion, 1);
+        assertFalse(rootCertChangedFromCurrent);
+        assertEq(rootCertCurrentVersion, 1);
+
+        assertTrue(qeChanged);
+        assertEq(qeVersion, 1);
+        assertFalse(qeChangedFromCurrent);
+        assertEq(qeCurrentVersion, 1);
+
+        assertTrue(tcbChanged);
+        assertEq(tcbVersion, 1);
+        assertFalse(tcbChangedFromCurrent);
+        assertEq(tcbCurrentVersion, 1);
+    }
+}

--- a/evm/foundry.toml
+++ b/evm/foundry.toml
@@ -5,14 +5,16 @@ libs = ['lib']
 script = 'forge-script'
 test = 'forge-test'
 cache_path  = 'cache_forge'
+allow_paths = ["../../automata-on-chain-pccs-upstream"]
 fs_permissions = [
     { access = "read", path = "./forge-test/assets"},
     { access = "read-write", path = "../rust-crates/libraries/network-registry/deployment/current"}
 ]
 remappings = [
-    "solady/=lib/automata-on-chain-pccs/lib/solady/src/",
+    "solady/=../../automata-on-chain-pccs-upstream/lib/solady/src/",
     "p256-verifier/=lib/automata-on-chain-pccs/lib/p256-verifier/src/",
-    "@automata-network/on-chain-pccs/=lib/automata-on-chain-pccs/src/",
+    "@automata-network/on-chain-pccs/=../../automata-on-chain-pccs-upstream/src/",
+    "@openzeppelin/contracts/=../../automata-on-chain-pccs-upstream/lib/openzeppelin-contracts/contracts/",
     "risc0/=lib/risc0-ethereum/contracts/src/",
     # foundry is not able to detect this particular remapping for some reason...
     "openzeppelin/=lib/risc0-ethereum/lib/openzeppelin-contracts/",


### PR DESCRIPTION
## Summary
- extend `IPCCSRouter` with collateral version and change-detection methods
- implement router wrappers for FMSPC TCB, QE Identity, and PCS collateral version checks
- add integration tests for router version APIs, auth/restriction behavior, missing-mapping reverts, and real update-driven version flips

## Validation
- `forge test forge-test/PCCSRouterVersioningTest.t.sol`
- `forge test` (full suite, with remapped patched PCCS checkout during local validation)
