### PR TITLE
fix: RFC 5280 inclusive validity bounds & emit tcbEval in UpdateConfig

### DIFF
--- a/evm/contracts/PCCSRouter.sol
+++ b/evm/contracts/PCCSRouter.sol
@@ -73,7 +73,7 @@ contract PCCSRouter is IPCCSRouter, Ownable {
     event SetCallerAuthorization(address caller, bool authorized);
     event UpdateCallerRestriction(bool restricted);
     event UpdateConfig(
-        address pcs, address pck, address x509, address x509Crl, address tcbHelper
+        address tcbEval, address pcs, address pck, address x509, address x509Crl, address tcbHelper
     );
     event UpdateQeIdDaoVersionedAddr(uint32 tcbEval, address addr);
     event UpdateFmspcTcbDaoVersionedAddr(uint32 tcbEval, address addr);
@@ -155,7 +155,7 @@ contract PCCSRouter is IPCCSRouter, Ownable {
         crlHelperAddr = _x509Crl;
         fmspcTcbHelperAddr = _tcbHelper;
 
-        emit UpdateConfig(_pcs, _pck, _x509, _x509Crl, _tcbHelper);
+        emit UpdateConfig(_tcbEval, _pcs, _pck, _x509, _x509Crl, _tcbHelper);
     }
 
     function getEarlyTcbEvaluationDataNumber(TcbId id) external view override onlyAuthorized returns (uint32) {

--- a/evm/contracts/bases/X509ChainBase.sol
+++ b/evm/contracts/bases/X509ChainBase.sol
@@ -113,7 +113,7 @@ abstract contract X509ChainBase is P256Verifier {
                 break;
             }
 
-            certNotExpired = block.timestamp > current.validityNotBefore && block.timestamp < current.validityNotAfter;
+            certNotExpired = block.timestamp >= current.validityNotBefore && block.timestamp <= current.validityNotAfter;
             if (!certNotExpired) {
                 break;
             }


### PR DESCRIPTION
Two small correctness fixes in the contracts.
1. X509ChainBase: use inclusive bounds for certificate validity period
2. PCCSRouter: include tcbEval address in `UpdateConfig` event