### PR TITLE
fix: handle nil Value in Callback.Value

### DIFF
--- a/go-sdk/packages/godcap/callback.go
+++ b/go-sdk/packages/godcap/callback.go
@@ -66,7 +66,7 @@ func (c *Callback) WithTo(to common.Address) *Callback {
 }
 
 func (c *Callback) Value() *big.Int {
-	if c == nil {
+	if c == nil || c.raw.Value == nil {
 		return new(big.Int)
 	}
 	return new(big.Int).Set(c.raw.Value)


### PR DESCRIPTION
Callback.Value() can panic if it is called before WithValue(), because NewCallback() leaves raw.Value unset and Value() passes it directly to (*big.Int).Set(). Abi() already handles this case by initializing raw.Value when it is nil, so this change makes Value() consistent by returning a zero-valued big.Int when raw.Value has not been initialized