### PR TITLE
fix(dcap): harden attestation input validation

### DIFF
--- a/rust-crates/libraries/dcap-rs/src/lib.rs
+++ b/rust-crates/libraries/dcap-rs/src/lib.rs
@@ -467,6 +467,9 @@ fn verify_integrity(
         .tcb_info
         .as_tcb_info_and_verify(current_time, tcb_signer)
         .context("failed to verify tcb info signature")?;
+    tcb_info
+        .validate_id_for_tee_type(quote.header.tee_type)
+        .context("TCB Info type does not match quote")?;
 
     // Verify the quote identity issuer chain
     let _qe_id_issuer = trust_store
@@ -500,7 +503,10 @@ pub fn verify_quote_enclave_source(
         .qe_identity
         .validate_as_enclave_identity(
             &VerifyingKey::from_sec1_bytes(
-                collateral.tcb_info_and_qe_identity_issuer_chain[0]
+                collateral
+                    .tcb_info_and_qe_identity_issuer_chain
+                    .first()
+                    .context("tcb issuer chain is empty")?
                     .tbs_certificate
                     .subject_public_key_info
                     .subject_public_key
@@ -510,6 +516,9 @@ pub fn verify_quote_enclave_source(
             .context("failed to verify quote enclave identity")?,
         )
         .context("failed to verify quote enclave identity")?;
+    qe_identity
+        .validate_id_for_tee_type(quote.header.tee_type)
+        .context("Quoting Enclave Identity type does not match quote")?;
 
     // Validate that current time is between issue_date and next_update
     let current_time: DateTime<Utc> = current_time.into();

--- a/rust-crates/libraries/dcap-rs/src/tdx.rs
+++ b/rust-crates/libraries/dcap-rs/src/tdx.rs
@@ -71,9 +71,8 @@ pub fn check_for_relaunch(
     let mut relaunch_needed = false;
     let mut configuration_needed = false;
 
-    if (qe_tcb_status != QeTcbStatus::OutOfDate
-        && qe_tcb_status != QeTcbStatus::OutOfDateConfigurationNeeded)
-        && !is_out_of_date(sgx_tcb_status)
+    if is_relaunch_eligible_qe_status(qe_tcb_status)
+        && is_relaunch_eligible_sgx_status(sgx_tcb_status)
         && is_out_of_date(tdx_tcb_status)
         && is_out_of_date(tdx_module_tcb_status)
     {
@@ -146,4 +145,48 @@ fn is_configuration_needed(tcb_status: TcbStatus) -> bool {
 
 fn is_out_of_date(tcb_status: TcbStatus) -> bool {
     tcb_status == TcbStatus::OutOfDate || tcb_status == TcbStatus::OutOfDateConfigurationNeeded
+}
+
+fn is_relaunch_eligible_qe_status(status: QeTcbStatus) -> bool {
+    matches!(
+        status,
+        QeTcbStatus::UpToDate
+            | QeTcbStatus::SWHardeningNeeded
+            | QeTcbStatus::ConfigurationNeeded
+            | QeTcbStatus::ConfigurationAndSWHardeningNeeded
+    )
+}
+
+fn is_relaunch_eligible_sgx_status(status: TcbStatus) -> bool {
+    matches!(
+        status,
+        TcbStatus::UpToDate
+            | TcbStatus::SWHardeningNeeded
+            | TcbStatus::ConfigurationNeeded
+            | TcbStatus::ConfigurationAndSWHardeningNeeded
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn relaunch_rejects_revoked_and_unknown_preliminary_statuses() {
+        assert!(!is_relaunch_eligible_qe_status(QeTcbStatus::Revoked));
+        assert!(!is_relaunch_eligible_qe_status(QeTcbStatus::Unspecified));
+        assert!(!is_relaunch_eligible_sgx_status(TcbStatus::Revoked));
+    }
+
+    #[test]
+    fn relaunch_accepts_intel_reference_preliminary_statuses() {
+        assert!(is_relaunch_eligible_qe_status(QeTcbStatus::UpToDate));
+        assert!(is_relaunch_eligible_qe_status(
+            QeTcbStatus::SWHardeningNeeded
+        ));
+        assert!(is_relaunch_eligible_sgx_status(TcbStatus::UpToDate));
+        assert!(is_relaunch_eligible_sgx_status(
+            TcbStatus::ConfigurationAndSWHardeningNeeded
+        ));
+    }
 }

--- a/rust-crates/libraries/dcap-rs/src/trust_store.rs
+++ b/rust-crates/libraries/dcap-rs/src/trust_store.rs
@@ -69,6 +69,10 @@ impl TrustStore {
         verify_signature: bool,
         intermediaries: Option<&BTreeMap<String, TrustedIdentity>>,
     ) -> anyhow::Result<()> {
+        if !crl.valid_at(self.current_time) {
+            bail!("certificate revocation list is not valid at the verification time");
+        }
+
         // Verify signature if requested
         if verify_signature {
             let issuer = crl.tbs_cert_list.issuer.to_string();
@@ -161,11 +165,12 @@ impl TrustStore {
         let issuer = cert.tbs_certificate.issuer.to_string();
         let serial = cert.tbs_certificate.serial_number.to_string();
 
-        // Check if this issuer has any revoked certificates
-        if let Some(issuer_revoked) = self.crl.get(&issuer) {
-            if issuer_revoked.contains(&serial) {
-                bail!("certificate is revoked");
-            }
+        let issuer_revoked = self
+            .crl
+            .get(&issuer)
+            .ok_or_else(|| anyhow::anyhow!("no certificate revocation list for issuer {issuer}"))?;
+        if issuer_revoked.contains(&serial) {
+            bail!("certificate is revoked");
         }
 
         Ok(())

--- a/rust-crates/libraries/dcap-rs/src/types/enclave_identity.rs
+++ b/rust-crates/libraries/dcap-rs/src/types/enclave_identity.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue;
 
 use super::tcb_info::TcbStatus;
+use crate::types::quote::{SGX_TEE_TYPE, TDX_TEE_TYPE};
 use crate::utils::keccak;
 
 const ENCLAVE_IDENTITY_V2: u32 = 2;
@@ -109,6 +110,25 @@ pub struct EnclaveIdentity {
 
     /// Sorted list of supported Enclave TCB levels for given QVE encoded as a JSON array of Enclave TCB level objects.
     pub tcb_levels: Vec<QeTcbLevel>,
+}
+
+impl EnclaveIdentity {
+    /// Require the Intel Quoting Enclave identity that belongs to the quote.
+    pub fn validate_id_for_tee_type(&self, tee_type: u32) -> anyhow::Result<()> {
+        let expected = match tee_type {
+            SGX_TEE_TYPE => EnclaveType::Qe,
+            TDX_TEE_TYPE => EnclaveType::TdQe,
+            other => anyhow::bail!("unsupported quote TEE type 0x{other:08x}"),
+        };
+        if self.id != expected {
+            anyhow::bail!(
+                "Enclave Identity id {:?} does not match quote TEE type 0x{tee_type:08x}; expected {:?}",
+                self.id,
+                expected
+            );
+        }
+        Ok(())
+    }
 }
 
 impl EnclaveIdentity {
@@ -305,6 +325,41 @@ impl From<EnclaveType> for u8 {
             EnclaveType::Qve => 1,
             EnclaveType::TdQe => 2,
         }
+    }
+}
+
+#[cfg(test)]
+mod collateral_id_tests {
+    use super::*;
+    use crate::types::quote::{SGX_TEE_TYPE, TDX_TEE_TYPE};
+
+    fn tdx_qe_identity() -> EnclaveIdentity {
+        serde_json::from_value(serde_json::json!({
+            "id": "TD_QE",
+            "version": 2,
+            "issueDate": "2026-01-01T00:00:00Z",
+            "nextUpdate": "2027-01-01T00:00:00Z",
+            "tcbEvaluationDataNumber": 1,
+            "miscselect": "00000000",
+            "miscselectMask": "FFFFFFFF",
+            "attributes": "00000000000000000000000000000000",
+            "attributesMask": "00000000000000000000000000000000",
+            "mrsigner": "0000000000000000000000000000000000000000000000000000000000000000",
+            "isvprodid": 0,
+            "tcbLevels": []
+        }))
+        .expect("minimal TDX Quoting Enclave Identity")
+    }
+
+    #[test]
+    fn enclave_identity_id_must_match_quote_tee_type() {
+        let mut identity = tdx_qe_identity();
+        identity.validate_id_for_tee_type(TDX_TEE_TYPE).unwrap();
+        assert!(identity.validate_id_for_tee_type(SGX_TEE_TYPE).is_err());
+
+        identity.id = EnclaveType::Qe;
+        identity.validate_id_for_tee_type(SGX_TEE_TYPE).unwrap();
+        assert!(identity.validate_id_for_tee_type(TDX_TEE_TYPE).is_err());
     }
 }
 

--- a/rust-crates/libraries/dcap-rs/src/types/quote/mod.rs
+++ b/rust-crates/libraries/dcap-rs/src/types/quote/mod.rs
@@ -32,9 +32,15 @@ impl<'a> Quote<'a> {
             return Err(anyhow!("incorrect buffer size"));
         }
 
-        // Read the quote header
-        let quote_header = utils::read_from_bytes::<QuoteHeader>(bytes)
-            .ok_or_else(|| anyhow!("underflow reading quote header"))?;
+        // Copy the fixed-size header so all semantic checks in QuoteHeader::try_from
+        // run before any attacker-controlled length or type is used.
+        let raw_header: [u8; std::mem::size_of::<QuoteHeader>()] = bytes
+            .get(..std::mem::size_of::<QuoteHeader>())
+            .ok_or_else(|| anyhow!("underflow reading quote header"))?
+            .try_into()
+            .map_err(|_| anyhow!("underflow reading quote header"))?;
+        *bytes = &bytes[std::mem::size_of::<QuoteHeader>()..];
+        let quote_header = QuoteHeader::try_from(raw_header)?;
 
         // Read the quote body and signature
         let quote_body_type;
@@ -217,7 +223,7 @@ impl<'a> std::fmt::Display for Quote<'a> {
 
 #[cfg(test)]
 mod error_tests {
-    use super::Quote;
+    use super::{Quote, QuoteHeader, Td10ReportBody};
 
     #[test]
     fn truncated_quotes_return_errors_without_panicking() {
@@ -233,6 +239,42 @@ mod error_tests {
                 assert!(result.is_ok(), "quote parser panicked at length {end}");
                 assert!(result.unwrap().is_err(), "truncated quote parsed at {end}");
             }
+        }
+    }
+
+    #[test]
+    fn quote_parser_enforces_header_security_fields() {
+        let quote = hex::decode(include_str!("../../../../../samples/quotev4.hex").trim()).unwrap();
+
+        let mut unsupported_version = quote.clone();
+        unsupported_version[0..2].copy_from_slice(&2u16.to_le_bytes());
+        assert!(Quote::read(&mut unsupported_version.as_slice()).is_err());
+
+        let mut unsupported_key = quote.clone();
+        unsupported_key[2..4].copy_from_slice(&3u16.to_le_bytes());
+        assert!(Quote::read(&mut unsupported_key.as_slice()).is_err());
+
+        let mut unsupported_vendor = quote;
+        unsupported_vendor[12] ^= 1;
+        assert!(Quote::read(&mut unsupported_vendor.as_slice()).is_err());
+    }
+
+    #[test]
+    fn quote_parser_enforces_declared_signature_length() {
+        let quote = hex::decode(include_str!("../../../../../samples/quotev4.hex").trim()).unwrap();
+        let signature_length_offset =
+            std::mem::size_of::<QuoteHeader>() + std::mem::size_of::<Td10ReportBody>();
+        let declared_length = u32::from_le_bytes(
+            quote[signature_length_offset..signature_length_offset + 4]
+                .try_into()
+                .unwrap(),
+        );
+
+        for invalid_length in [declared_length - 1, declared_length + 1] {
+            let mut invalid_quote = quote.clone();
+            invalid_quote[signature_length_offset..signature_length_offset + 4]
+                .copy_from_slice(&invalid_length.to_le_bytes());
+            assert!(Quote::read(&mut invalid_quote.as_slice()).is_err());
         }
     }
 }

--- a/rust-crates/libraries/dcap-rs/src/types/quote/signature.rs
+++ b/rust-crates/libraries/dcap-rs/src/types/quote/signature.rs
@@ -46,13 +46,23 @@ impl<'a> QuoteSignatureData<'a> {
             return Err(anyhow!("underflow reading signature"));
         }
 
-        if version == 3 {
-            Self::read_v3_signature(bytes)
+        let (signature_bytes, remaining) = bytes.split_at(signature_len as usize);
+        let mut signature_bytes = signature_bytes;
+        let signature = if version == 3 {
+            Self::read_v3_signature(&mut signature_bytes)
         } else if version >= 4 {
-            Self::read_v4_signature(bytes)
+            Self::read_v4_signature(&mut signature_bytes)
         } else {
-            Err(anyhow!("unsupported quote version"))
+            return Err(anyhow!("unsupported quote version"));
+        }?;
+        if !signature_bytes.is_empty() {
+            return Err(anyhow!(
+                "signature data has {} trailing bytes",
+                signature_bytes.len()
+            ));
         }
+        *bytes = remaining;
+        Ok(signature)
     }
 
     fn read_v3_signature(bytes: &mut &'a [u8]) -> anyhow::Result<Self> {
@@ -129,6 +139,12 @@ impl<'a> QuoteSignatureData<'a> {
         )
         .ok_or_else(|| anyhow!("underflow reading QE authentication data"))?;
         let cert_data = QuoteCertData::read(&mut cert_data_struct.cert_data)?;
+        if !cert_data_struct.cert_data.is_empty() {
+            return Err(anyhow!(
+                "QE report certification data has {} trailing bytes",
+                cert_data_struct.cert_data.len()
+            ));
+        }
 
         Ok(QuoteSignatureData {
             isv_signature,

--- a/rust-crates/libraries/dcap-rs/src/types/tcb_info.rs
+++ b/rust-crates/libraries/dcap-rs/src/types/tcb_info.rs
@@ -7,7 +7,10 @@ use p256::ecdsa::signature::Verifier;
 use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue;
 
-use crate::types::{quote::TDX_TEE_TYPE, report::Td10ReportBody};
+use crate::types::{
+    quote::{SGX_TEE_TYPE, TDX_TEE_TYPE},
+    report::Td10ReportBody,
+};
 use crate::utils::keccak;
 
 use super::{
@@ -106,6 +109,56 @@ impl From<TcbInfoVersion> for u32 {
     }
 }
 
+#[cfg(test)]
+mod collateral_id_tests {
+    use super::*;
+    use crate::types::quote::{SGX_TEE_TYPE, TDX_TEE_TYPE};
+
+    fn tdx_tcb_info() -> TcbInfo {
+        serde_json::from_value(serde_json::json!({
+            "id": "TDX",
+            "version": 3,
+            "issueDate": "2026-01-01T00:00:00Z",
+            "nextUpdate": "2027-01-01T00:00:00Z",
+            "fmspc": "000000000000",
+            "pceId": "0000",
+            "tcbType": 0,
+            "tcbEvaluationDataNumber": 1,
+            "tcbLevels": []
+        }))
+        .expect("minimal TDX TCB Info")
+    }
+
+    #[test]
+    fn tcb_info_id_must_match_quote_tee_type() {
+        let mut info = tdx_tcb_info();
+        info.validate_id_for_tee_type(TDX_TEE_TYPE).unwrap();
+        assert!(info.validate_id_for_tee_type(SGX_TEE_TYPE).is_err());
+
+        info.id = Some("SGX".into());
+        info.validate_id_for_tee_type(SGX_TEE_TYPE).unwrap();
+        assert!(info.validate_id_for_tee_type(TDX_TEE_TYPE).is_err());
+    }
+
+    #[test]
+    fn version_three_tcb_info_requires_id() {
+        let mut info = tdx_tcb_info();
+        info.id = None;
+        assert!(info.validate_id_for_tee_type(TDX_TEE_TYPE).is_err());
+        assert!(info.validate_id_for_tee_type(SGX_TEE_TYPE).is_err());
+    }
+
+    #[test]
+    fn version_two_tcb_info_cannot_describe_tdx() {
+        let mut info = tdx_tcb_info();
+        info.version = TcbInfoVersion::V2;
+        assert!(info.validate_id_for_tee_type(TDX_TEE_TYPE).is_err());
+
+        info.id = None;
+        info.validate_id_for_tee_type(SGX_TEE_TYPE).unwrap();
+    }
+}
+
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TcbInfo {
@@ -128,6 +181,42 @@ pub struct TcbInfo {
 }
 
 impl TcbInfo {
+    /// Require the Intel TCB Info document type that belongs to the quote.
+    ///
+    /// Version 2 TCB Info predates the `id` field and only describes SGX.
+    /// Version 3 collateral must carry an explicit `SGX` or `TDX` identifier.
+    pub fn validate_id_for_tee_type(&self, tee_type: u32) -> anyhow::Result<()> {
+        if self.version == TcbInfoVersion::V2 {
+            if tee_type != SGX_TEE_TYPE {
+                bail!(
+                    "TCB Info version 2 only describes SGX and cannot match quote TEE type 0x{tee_type:08x}"
+                );
+            }
+            return match self.id.as_deref() {
+                None | Some("SGX") => Ok(()),
+                Some(actual) => {
+                    bail!("TCB Info version 2 has invalid id {actual:?}; expected \"SGX\" or no id")
+                },
+            };
+        }
+
+        let expected = match tee_type {
+            SGX_TEE_TYPE => "SGX",
+            TDX_TEE_TYPE => "TDX",
+            other => bail!("unsupported quote TEE type 0x{other:08x}"),
+        };
+        match self.id.as_deref() {
+            Some(actual) if actual == expected => Ok(()),
+            Some(actual) => bail!(
+                "TCB Info id {actual:?} does not match quote TEE type 0x{tee_type:08x}; expected {expected:?}"
+            ),
+            None => bail!(
+                "TCB Info version {} is missing id; expected {expected:?} for quote TEE type 0x{tee_type:08x}",
+                u32::from(self.version)
+            ),
+        }
+    }
+
     pub fn fmspc_bytes(&self) -> Result<[u8; 6]> {
         decode_hex_array(&self.fmspc, "TCB info FMSPC")
     }

--- a/rust-crates/libraries/dcap-rs/src/utils.rs
+++ b/rust-crates/libraries/dcap-rs/src/utils.rs
@@ -268,10 +268,11 @@ pub trait Expireable {
 impl Expireable for CertificateList {
     /// Validate CRL creation/expiration
     fn valid_at(&self, timestamp: SystemTime) -> bool {
-        if let Some(na) = self.tbs_cert_list.next_update.map(|t| t.to_system_time()) {
-            if na <= timestamp {
-                return false;
-            }
+        let Some(na) = self.tbs_cert_list.next_update.map(|t| t.to_system_time()) else {
+            return false;
+        };
+        if na <= timestamp {
+            return false;
         }
 
         // return false if the crl is for the future

--- a/rust-crates/libraries/dcap-rs/tests/tests.rs
+++ b/rust-crates/libraries/dcap-rs/tests/tests.rs
@@ -43,6 +43,35 @@ async fn e2e_v4_quote() {
 }
 
 #[tokio::test]
+async fn e2e_v4_quote_rejects_root_crl_as_pck_crl() {
+    let (mut collateral, quote) = v4_quote_data().await;
+    collateral.pck_crl = collateral.root_ca_crl.clone();
+    let error = verify_dcap_quote(test_v4_time(), collateral, quote)
+        .expect_err("the root CA CRL must not cover a PCK certificate");
+    assert!(
+        format!("{error:#}").contains("no certificate revocation list for issuer"),
+        "{error:#}"
+    );
+}
+
+#[tokio::test]
+async fn e2e_v4_quote_rejects_expired_crl() {
+    let (collateral, quote) = v4_quote_data().await;
+    let expired_at = collateral
+        .pck_crl
+        .tbs_cert_list
+        .next_update
+        .expect("Intel PCK CRL should have nextUpdate")
+        .to_system_time();
+    let error = verify_dcap_quote(expired_at, collateral, quote)
+        .expect_err("a CRL must not be accepted at or after nextUpdate");
+    assert!(
+        format!("{error:#}").contains("certificate revocation list is not valid"),
+        "{error:#}"
+    );
+}
+
+#[tokio::test]
 async fn e2e_v5_quote() {
     let (collateral, quote) = v5_quote_data().await;
     let policy = DcapVerificationPolicy {

--- a/rust-crates/libraries/utils/src/parser.rs
+++ b/rust-crates/libraries/utils/src/parser.rs
@@ -1,6 +1,6 @@
 use crate::version::Version;
 use alloy::sol_types::SolValue;
-use anyhow::Result;
+use anyhow::{Context, Result};
 use dcap_rs::types::{
     quote::{Quote, QuoteBody},
     report::{EnclaveReportBody, Td10ReportBody},
@@ -29,28 +29,35 @@ pub fn parse_quote<'a>(quote_bytes: &'a [u8]) -> Result<Quote<'a>> {
 /// Parsed VerifiedOutput structure (version-aware)
 pub fn parse_output(output_bytes: &[u8], version: Version) -> Result<VerifiedOutput> {
     match version {
-        Version::V1_0 => {
-            parse_legacy_output(output_bytes)
-        }
-        Version::V1_1 => {
-            Ok(VerifiedOutput::from_bytes(output_bytes)?)
-        }
+        Version::V1_0 => parse_legacy_output(output_bytes),
+        Version::V1_1 => Ok(VerifiedOutput::from_bytes(output_bytes)?),
     }
 }
 
 fn parse_legacy_output(output_bytes: &[u8]) -> Result<VerifiedOutput> {
-    let mut quote_version = [0; 2];
-    quote_version.copy_from_slice(&output_bytes[0..2]);
-    let mut tee_type = [0; 4];
-    tee_type.copy_from_slice(&output_bytes[2..6]);
-    let tcb_status = output_bytes[6];
-    let mut fmspc = [0; 6];
-    fmspc.copy_from_slice(&output_bytes[7..13]);
+    let header = output_bytes
+        .get(..13)
+        .context("legacy verified output is shorter than its 13-byte header")?;
+    let quote_version = header[0..2]
+        .try_into()
+        .context("legacy quote version has the wrong length")?;
+    let tee_type = header[2..6]
+        .try_into()
+        .context("legacy TEE type has the wrong length")?;
+    let tcb_status = header[6];
+    let fmspc = header[7..13]
+        .try_into()
+        .context("legacy FMSPC has the wrong length")?;
 
     let mut offset = 13usize;
     let (quote_body_type, quote_body) = match u32::from_le_bytes(tee_type) {
         0x00000000 => {
-            let raw_quote_body = &output_bytes[offset..offset + 384];
+            let end = offset
+                .checked_add(384)
+                .context("legacy SGX quote body offset overflow")?;
+            let raw_quote_body = output_bytes
+                .get(offset..end)
+                .context("legacy verified output has a truncated 384-byte SGX quote body")?;
             offset += 384;
             let body_array: [u8; 384] = raw_quote_body.try_into()?;
             (
@@ -59,7 +66,12 @@ fn parse_legacy_output(output_bytes: &[u8]) -> Result<VerifiedOutput> {
             )
         }
         0x00000081 => {
-            let raw_quote_body = &output_bytes[offset..offset + 584];
+            let end = offset
+                .checked_add(584)
+                .context("legacy TDX quote body offset overflow")?;
+            let raw_quote_body = output_bytes
+                .get(offset..end)
+                .context("legacy verified output has a truncated 584-byte TDX quote body")?;
             offset += 584;
             let body_array: [u8; 584] = raw_quote_body.try_into()?;
             (
@@ -73,7 +85,10 @@ fn parse_legacy_output(output_bytes: &[u8]) -> Result<VerifiedOutput> {
     let mut advisory_ids = None;
     if offset < output_bytes.len() {
         let advisory_ids_slice = &output_bytes[offset..];
-        advisory_ids = Some(<Vec<String>>::abi_decode(advisory_ids_slice).unwrap());
+        advisory_ids = Some(
+            <Vec<String>>::abi_decode(advisory_ids_slice)
+                .context("legacy advisory ID ABI data is malformed")?,
+        );
     }
 
     Ok(VerifiedOutput {
@@ -84,4 +99,37 @@ fn parse_legacy_output(output_bytes: &[u8]) -> Result<VerifiedOutput> {
         quote_body,
         advisory_ids,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn legacy_parser_returns_errors_for_truncated_inputs() {
+        for input in [Vec::new(), vec![0; 12], vec![0; 13], vec![0; 13 + 383]] {
+            let result = std::panic::catch_unwind(|| parse_output(&input, Version::V1_0));
+            assert!(
+                result.is_ok(),
+                "legacy parser panicked for {} bytes",
+                input.len()
+            );
+            assert!(
+                result.unwrap().is_err(),
+                "legacy parser accepted {} truncated bytes",
+                input.len()
+            );
+        }
+    }
+
+    #[test]
+    fn legacy_parser_returns_error_for_malformed_advisory_ids() {
+        let mut input = vec![0; 13 + 384];
+        input[0..2].copy_from_slice(&3u16.to_be_bytes());
+        input.extend_from_slice(&[1, 2, 3]);
+
+        let result = std::panic::catch_unwind(|| parse_output(&input, Version::V1_0));
+        assert!(result.is_ok(), "legacy advisory parser panicked");
+        assert!(result.unwrap().is_err());
+    }
 }

--- a/rust-crates/libraries/utils/src/wasm/mod.rs
+++ b/rust-crates/libraries/utils/src/wasm/mod.rs
@@ -14,8 +14,6 @@
 
 mod wrapper;
 
-use core::panic;
-
 use anyhow::{bail, Result};
 use serde_wasm_bindgen;
 use wasm_bindgen::prelude::*;
@@ -38,14 +36,19 @@ use wrapper::QuoteWrapper;
 /// # Returns
 /// Serialized `VerifiedOutput` as a `JsValue`
 #[wasm_bindgen]
-pub fn parse_verified_output(output_bytes: &[u8], version_str: &str) -> JsValue {
+pub fn parse_verified_output(
+    output_bytes: &[u8],
+    version_str: &str,
+) -> std::result::Result<JsValue, JsValue> {
     let version = version_str
         .parse::<Version>()
-        .expect("Invalid version string");
+        .map_err(|error| JsValue::from_str(&format!("invalid version string: {error}")))?;
 
-    let output =
-        parser::parse_output(output_bytes, version).expect("Failed to parse verified output");
-    serde_wasm_bindgen::to_value(&output).unwrap()
+    let output = parser::parse_output(output_bytes, version)
+        .map_err(|error| JsValue::from_str(&format!("failed to parse verified output: {error}")))?;
+    serde_wasm_bindgen::to_value(&output).map_err(|error| {
+        JsValue::from_str(&format!("failed to serialize verified output: {error}"))
+    })
 }
 
 // =============================================================================
@@ -60,13 +63,15 @@ pub fn parse_verified_output(output_bytes: &[u8], version_str: &str) -> JsValue 
 /// # Returns
 /// Serialized `QuoteWrapper` as a `JsValue`
 #[wasm_bindgen]
-pub fn parse_quote_js(quote_bytes: &[u8]) -> JsValue {
-    let quote = parser::parse_quote(quote_bytes).expect("Failed to parse quote");
+pub fn parse_quote_js(quote_bytes: &[u8]) -> std::result::Result<JsValue, JsValue> {
+    let quote = parser::parse_quote(quote_bytes)
+        .map_err(|error| JsValue::from_str(&format!("failed to parse quote: {error}")))?;
 
     // Convert to owned wrapper for serialization
     let quote_wrapper = QuoteWrapper::from(&quote);
 
-    serde_wasm_bindgen::to_value(&quote_wrapper).unwrap()
+    serde_wasm_bindgen::to_value(&quote_wrapper)
+        .map_err(|error| JsValue::from_str(&format!("failed to serialize quote: {error}")))
 }
 
 // =============================================================================
@@ -83,15 +88,15 @@ pub fn parse_quote_js(quote_bytes: &[u8]) -> JsValue {
 /// # Returns
 /// Serialized `LocatedQuoteOutput` containing the quote, version, and raw bytes
 #[wasm_bindgen]
-pub fn locate_raw_quote_js(txn_data: &[u8], quote_version: u16, idx: usize) -> JsValue {
-    let located_quote = locate_raw_quote(txn_data, quote_version, idx);
-    match located_quote {
-        Ok(quote_bytes) => serde_wasm_bindgen::to_value(&quote_bytes).unwrap(),
-        Err(e) => {
-            let error_msg = format!("Error locating quote: {}", e);
-            panic!("{}", error_msg);
-        }
-    }
+pub fn locate_raw_quote_js(
+    txn_data: &[u8],
+    quote_version: u16,
+    idx: usize,
+) -> std::result::Result<JsValue, JsValue> {
+    let quote_bytes = locate_raw_quote(txn_data, quote_version, idx)
+        .map_err(|error| JsValue::from_str(&format!("error locating quote: {error}")))?;
+    serde_wasm_bindgen::to_value(&quote_bytes)
+        .map_err(|error| JsValue::from_str(&format!("failed to serialize quote bytes: {error}")))
 }
 
 /// Get the number of possible quote locations within transaction data
@@ -103,9 +108,13 @@ pub fn locate_raw_quote_js(txn_data: &[u8], quote_version: u16, idx: usize) -> J
 /// # Returns
 /// Number of possible quote locations found
 #[wasm_bindgen]
-pub fn locate_possible_quote_length_js(txn_data: &[u8], quote_version: u8) -> JsValue {
+pub fn locate_possible_quote_length_js(
+    txn_data: &[u8],
+    quote_version: u8,
+) -> std::result::Result<JsValue, JsValue> {
     let length = locate_possible_quote_length(txn_data, quote_version);
-    serde_wasm_bindgen::to_value(&length).unwrap()
+    serde_wasm_bindgen::to_value(&length)
+        .map_err(|error| JsValue::from_str(&format!("failed to serialize quote count: {error}")))
 }
 
 // =============================================================================
@@ -146,8 +155,8 @@ pub fn locate_raw_quote(txn_data: &[u8], quote_version: u16, idx: usize) -> Resu
 /// all byte sequences starting from each match.
 pub fn find_possible_quote_bytes_vec(txn_data: &[u8], quote_version: u8) -> Vec<Vec<u8>> {
     let mut results: Vec<Vec<u8>> = Vec::new();
-    for i in 0..txn_data.len() - 1 {
-        if txn_data[i] == quote_version && txn_data[i + 1] == 0 {
+    for (i, bytes) in txn_data.windows(2).enumerate() {
+        if bytes == [quote_version, 0] {
             let sub_slice = txn_data[i..].to_vec();
             results.push(sub_slice);
         }
@@ -158,6 +167,12 @@ pub fn find_possible_quote_bytes_vec(txn_data: &[u8], quote_version: u8) -> Vec<
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn empty_transaction_data_has_no_quote_locations() {
+        assert_eq!(locate_possible_quote_length(&[], 4), 0);
+        assert!(locate_raw_quote(&[], 4, 0).is_err());
+    }
 
     #[test]
     fn test_locate_raw_quote_v3() {

--- a/rust-crates/libraries/zkvm/src/common/inputs.rs
+++ b/rust-crates/libraries/zkvm/src/common/inputs.rs
@@ -51,11 +51,8 @@ fn generate_input_v1_1(
 
     // Solidity ABI encode: (bytes collateral, bytes quote, uint64 timestamp)
     let collateral_encoded = collateral.sol_abi_encode()?;
-    let input = GuestInputSolType::abi_encode_params(&(
-        collateral_encoded.as_slice(),
-        quote,
-        timestamp,
-    ));
+    let input =
+        GuestInputSolType::abi_encode_params(&(collateral_encoded.as_slice(), quote, timestamp));
 
     Ok(input)
 }
@@ -119,7 +116,8 @@ fn serialize_collateral_v1_0(
     match pck_type {
         PckType::Platform => {
             data.extend_from_slice(&(0u32).to_le_bytes()); // processor_crl_len = 0
-            data.extend_from_slice(&(collaterals.pck_crl.len() as u32).to_le_bytes()); // platform_crl_len
+            data.extend_from_slice(&(collaterals.pck_crl.len() as u32).to_le_bytes());
+            // platform_crl_len
         }
         PckType::Processor => {
             data.extend_from_slice(&(collaterals.pck_crl.len() as u32).to_le_bytes()); // processor_crl_len
@@ -145,25 +143,49 @@ fn detect_pck_type(quote: &[u8]) -> Result<PckType> {
     use x509_parser::prelude::*;
 
     // Determine quote version and TEE type
-    let quote_version = u16::from_le_bytes([quote[0], quote[1]]);
-    let tee_type = u32::from_le_bytes([quote[4], quote[5], quote[6], quote[7]]);
+    let header = quote
+        .get(..8)
+        .context("Quote is shorter than the 8-byte header fields needed for PCK detection")?;
+    let quote_version = u16::from_le_bytes(
+        header[0..2]
+            .try_into()
+            .context("Quote version has the wrong length")?,
+    );
+    let tee_type = u32::from_le_bytes(
+        header[4..8]
+            .try_into()
+            .context("Quote TEE type has the wrong length")?,
+    );
 
     // Calculate QE Auth Data Size offset based on version and TEE type
     // Reference: dcap-sp1-cli/src/parser.rs:7-12
     let offset: usize = if quote_version < 4 {
-        1012  // V3_SGX_QE_AUTH_DATA_SIZE_OFFSET
-    } else if tee_type == 0x00000000 {  // SGX_TEE_TYPE
-        1018  // V4_SGX_QE_AUTH_DATA_SIZE_OFFSET
+        1012 // V3_SGX_QE_AUTH_DATA_SIZE_OFFSET
+    } else if tee_type == 0x00000000 {
+        // SGX_TEE_TYPE
+        1018 // V4_SGX_QE_AUTH_DATA_SIZE_OFFSET
     } else {
-        1218  // V4_TDX_QE_AUTH_DATA_SIZE_OFFSET
+        1218 // V4_TDX_QE_AUTH_DATA_SIZE_OFFSET
     };
 
     // Get certificate data offset
-    let auth_data_size = u16::from_le_bytes([quote[offset], quote[offset + 1]]);
-    let cert_data_offset = offset + 2 + auth_data_size as usize + 2 + 4;
+    let auth_data_size = u16::from_le_bytes(
+        quote
+            .get(offset..offset + 2)
+            .context("Quote is truncated before QE authentication data size")?
+            .try_into()
+            .context("QE authentication data size has the wrong length")?,
+    );
+    let cert_data_offset = offset
+        .checked_add(2)
+        .and_then(|value| value.checked_add(usize::from(auth_data_size)))
+        .and_then(|value| value.checked_add(2 + 4))
+        .context("PCK certificate data offset overflow")?;
 
     // Parse PCK certificate from quote
-    let cert_data = &quote[cert_data_offset..];
+    let cert_data = quote
+        .get(cert_data_offset..)
+        .context("Quote is truncated before PCK certificate data")?;
     let pem = Pem::iter_from_buffer(cert_data)
         .collect::<Result<Vec<_>, _>>()
         .context("Failed to parse PEM certificates")?;
@@ -172,7 +194,9 @@ fn detect_pck_type(quote: &[u8]) -> Result<PckType> {
         anyhow::bail!("No certificates found in quote");
     }
 
-    let cert = pem[0].parse_x509().context("Failed to parse X509 certificate")?;
+    let cert = pem[0]
+        .parse_x509()
+        .context("Failed to parse X509 certificate")?;
 
     // Extract issuer CN to determine Platform vs Processor
     let issuer = cert.issuer();
@@ -187,6 +211,28 @@ fn detect_pck_type(quote: &[u8]) -> Result<PckType> {
         "Intel SGX PCK Platform CA" => Ok(PckType::Platform),
         "Intel SGX PCK Processor CA" => Ok(PckType::Processor),
         _ => anyhow::bail!("Unknown PCK issuer: {}", cn),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pck_type_detection_returns_errors_for_truncated_quotes() {
+        for quote in [Vec::new(), vec![0; 7], vec![0; 8], vec![0; 1_013]] {
+            let result = std::panic::catch_unwind(|| detect_pck_type(&quote));
+            assert!(
+                result.is_ok(),
+                "PCK type detection panicked for {} bytes",
+                quote.len()
+            );
+            assert!(
+                result.unwrap().is_err(),
+                "PCK type detection accepted {} truncated bytes",
+                quote.len()
+            );
+        }
     }
 }
 

--- a/rust-crates/libraries/zkvm/src/common/outputs.rs
+++ b/rust-crates/libraries/zkvm/src/common/outputs.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use automata_dcap_utils::{parser::parse_output as utils_parse_output, Version};
 use dcap_rs::types::VerifiedOutput;
 use serde::{Deserialize, Serialize};
@@ -14,28 +14,33 @@ use std::path::Path;
 /// Parsed output structure containing VerifiedOutput and collateral hashes
 pub fn parse_output(output: &[u8], version: Version) -> Result<ParsedOutput> {
     let mut offset: usize = 0;
-    let output_len = u16::from_be_bytes(output[offset..offset + 2].try_into()?);
-
-    offset += 2;
-    let raw_verified_output = &output[offset..offset + output_len as usize];
+    let output_len = u16::from_be_bytes(
+        take(output, &mut offset, 2, "verified output length")?
+            .try_into()
+            .context("verified output length has the wrong size")?,
+    );
+    let raw_verified_output = take(
+        output,
+        &mut offset,
+        usize::from(output_len),
+        "verified output",
+    )?;
 
     // Use utils crate for version-aware VerifiedOutput parsing
     let verified_output = utils_parse_output(raw_verified_output, version)?;
-    offset += output_len as usize;
 
-    let current_time = u64::from_be_bytes(output[offset..offset + 8].try_into()?);
-    offset += 8;
-    let tcbinfo_root_hash = output[offset..offset + 32].to_vec();
-    offset += 32;
-    let enclaveidentity_root_hash = output[offset..offset + 32].to_vec();
-    offset += 32;
-    let root_cert_hash = output[offset..offset + 32].to_vec();
-    offset += 32;
-    let signing_cert_hash = output[offset..offset + 32].to_vec();
-    offset += 32;
-    let root_crl_hash = output[offset..offset + 32].to_vec();
-    offset += 32;
-    let pck_crl_hash = output[offset..offset + 32].to_vec();
+    let current_time = u64::from_be_bytes(
+        take(output, &mut offset, 8, "current time")?
+            .try_into()
+            .context("current time has the wrong size")?,
+    );
+    let tcbinfo_root_hash = take(output, &mut offset, 32, "TCB Info root hash")?.to_vec();
+    let enclaveidentity_root_hash =
+        take(output, &mut offset, 32, "Enclave Identity root hash")?.to_vec();
+    let root_cert_hash = take(output, &mut offset, 32, "root certificate hash")?.to_vec();
+    let signing_cert_hash = take(output, &mut offset, 32, "signing certificate hash")?.to_vec();
+    let root_crl_hash = take(output, &mut offset, 32, "root CRL hash")?.to_vec();
+    let pck_crl_hash = take(output, &mut offset, 32, "PCK CRL hash")?.to_vec();
 
     Ok(ParsedOutput {
         verified_output,
@@ -49,6 +54,21 @@ pub fn parse_output(output: &[u8], version: Version) -> Result<ParsedOutput> {
     })
 }
 
+fn take<'a>(input: &'a [u8], offset: &mut usize, length: usize, field: &str) -> Result<&'a [u8]> {
+    let end = offset
+        .checked_add(length)
+        .with_context(|| format!("{field} offset overflow"))?;
+    let value = input.get(*offset..end).with_context(|| {
+        format!(
+            "output is truncated while reading {field}: need {length} bytes at offset {}, total length {}",
+            *offset,
+            input.len()
+        )
+    })?;
+    *offset = end;
+    Ok(value)
+}
+
 /// Structured output from parsing the guest program journal
 pub struct ParsedOutput {
     pub verified_output: VerifiedOutput,
@@ -59,6 +79,28 @@ pub struct ParsedOutput {
     pub signing_cert_hash: Vec<u8>,
     pub root_crl_hash: Vec<u8>,
     pub pck_crl_hash: Vec<u8>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn output_parser_returns_errors_for_truncated_inputs() {
+        for input in [Vec::new(), vec![0], vec![0, 8], vec![0, 1, 0]] {
+            let result = std::panic::catch_unwind(|| parse_output(&input, Version::V1_0));
+            assert!(
+                result.is_ok(),
+                "output parser panicked for {} bytes",
+                input.len()
+            );
+            assert!(
+                result.unwrap().is_err(),
+                "output parser accepted {} truncated bytes",
+                input.len()
+            );
+        }
+    }
 }
 
 /// Proof artifact that can be serialized to JSON

--- a/rust-crates/libraries/zkvm/src/common/workflow.rs
+++ b/rust-crates/libraries/zkvm/src/common/workflow.rs
@@ -1,5 +1,5 @@
 use alloy::providers::Provider;
-use anyhow::Result;
+use anyhow::{Context, Result};
 use automata_dcap_network_registry::Network;
 use automata_dcap_utils::Version;
 
@@ -38,7 +38,7 @@ pub async fn prepare_guest_input<P: Provider>(
     metadata.log_info();
     let quote_version = metadata.version;
 
-    if deployment_version.unwrap() == Version::V1_0 {
+    if deployment_version == Some(Version::V1_0) {
         if quote_version != 3 && quote_version != 4 {
             return Err(anyhow::anyhow!(
                 "Incompatible quote version for DCAP v1.0: expected version 3 or 4, got version {}",
@@ -79,7 +79,7 @@ pub async fn prepare_guest_input<P: Provider>(
     // Step 2: Generate version-aware input bytes with current timestamp
     let current_time = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
+        .context("System clock is before the Unix epoch")?
         .as_secs();
 
     let version = deployment_version.unwrap_or(Version::V1_1);

--- a/rust-crates/libraries/zkvm/src/pico/cli.rs
+++ b/rust-crates/libraries/zkvm/src/pico/cli.rs
@@ -48,21 +48,34 @@ pub struct PicoGenerateEvmInputsArgs {
 }
 
 /// Handle Pico CLI commands
-pub async fn run<P: Provider>(command: PicoCommand, quote_bytes: Option<Vec<u8>>, provider: &P, version: automata_dcap_utils::Version, tcb_eval_num: Option<u32>) -> Result<()> {
+pub async fn run<P: Provider>(
+    command: PicoCommand,
+    quote_bytes: Option<Vec<u8>>,
+    provider: &P,
+    version: automata_dcap_utils::Version,
+    tcb_eval_num: Option<u32>,
+) -> Result<()> {
     match command {
         PicoCommand::Prove(args) => {
             let quote_bytes = quote_bytes.context("Quote bytes must be provided for proving")?;
             prove(&args, quote_bytes, provider, version, tcb_eval_num).await
-        },
+        }
         PicoCommand::GenerateEvmInputs(args) => generate_evm_inputs(&args),
         PicoCommand::ProgramId => program_id(version),
     }
 }
 
 /// Generate proof for DCAP quote verification
-async fn prove<P: Provider>(args: &PicoProveArgs, quote_bytes: Vec<u8>, provider: &P, version: automata_dcap_utils::Version, tcb_eval_num: Option<u32>) -> Result<()> {
+async fn prove<P: Provider>(
+    args: &PicoProveArgs,
+    quote_bytes: Vec<u8>,
+    provider: &P,
+    version: automata_dcap_utils::Version,
+    tcb_eval_num: Option<u32>,
+) -> Result<()> {
     // Prepare version-aware guest input using common workflow
-    let input_bytes = prepare_guest_input(provider, Some(version), &quote_bytes, tcb_eval_num).await?;
+    let input_bytes =
+        prepare_guest_input(provider, Some(version), &quote_bytes, tcb_eval_num).await?;
 
     // Create version-aware prover
     let prover = PicoProver::new(version)?;
@@ -138,7 +151,9 @@ fn generate_evm_inputs(args: &PicoGenerateEvmInputsArgs) -> Result<()> {
     // Get proof from proof.data
     let proof_data = fs::read_to_string(&proof_path)?;
     let proof_slice: Vec<String> = proof_data.split(',').map(|s| s.to_string()).collect();
-    let proof = &proof_slice[0..8];
+    let proof = proof_slice
+        .get(..8)
+        .context("proof.data must contain at least 8 comma-separated proof values")?;
 
     // Get pv stream from pv file
     let pv_file_path = artifacts_path.join(PV_FILE);
@@ -147,11 +162,15 @@ fn generate_evm_inputs(args: &PicoGenerateEvmInputsArgs) -> Result<()> {
     }
     let pv_file_content = fs::read_to_string(&pv_file_path)?;
     let pv_string = pv_file_content.trim();
-    if !pv_string[2..].chars().all(|c| c.is_ascii_hexdigit()) {
+    let pv_hex = pv_string
+        .strip_prefix("0x")
+        .context("pv file must start with 0x")?;
+    if pv_hex.is_empty() || pv_hex.len() % 2 != 0 || !pv_hex.chars().all(|c| c.is_ascii_hexdigit())
+    {
         anyhow::bail!("Invalid hex format in pv file");
     }
 
-    let public_values_hex = "0x".to_string() + pv_string;
+    let public_values_hex = pv_string.to_string();
     let result_json = json!({
         "riscvVKey": vkey_hex,
         "proof": proof,
@@ -167,7 +186,10 @@ fn generate_evm_inputs(args: &PicoGenerateEvmInputsArgs) -> Result<()> {
     let mut contract_input_file = File::create(&contract_input_path)?;
     contract_input_file.write_all(json_string.as_bytes())?;
 
-    println!("Generated EVM contract inputs at: {}", contract_input_path.display());
+    println!(
+        "Generated EVM contract inputs at: {}",
+        contract_input_path.display()
+    );
 
     Ok(())
 }

--- a/rust-crates/libraries/zkvm/src/pico/prover.rs
+++ b/rust-crates/libraries/zkvm/src/pico/prover.rs
@@ -4,8 +4,11 @@ use p3_field::PrimeField;
 use pico_sdk::client::{DefaultProverClient, KoalaBearProverClient};
 use pico_sdk::HashableKey;
 
-use crate::{common::{ZkVmProver, ZkVm}, get_elf, Version};
 use super::config::PicoConfig;
+use crate::{
+    common::{ZkVm, ZkVmProver},
+    get_elf, Version,
+};
 
 /// Pico zkVM prover implementation
 pub struct PicoProver {
@@ -36,9 +39,13 @@ impl ZkVmProver for PicoProver {
         log::info!("EVM Emulation Cycles: {}", cycles);
 
         // Generate proof if not in dev mode
-        if std::env::var("DEV_MODE").is_err() || std::env::var("DEV_MODE").unwrap().is_empty() {
-            println!("Begin proving with Pico zkVM (field: {})", config.field_type);
-            
+        let dev_mode = matches!(std::env::var("DEV_MODE"), Ok(value) if !value.is_empty());
+        if !dev_mode {
+            println!(
+                "Begin proving with Pico zkVM (field: {})",
+                config.field_type
+            );
+
             // Check if trusted setup is needed (vm_pk exists)
             let proving_key_path = config.artifacts_path.join("vm_pk");
             let need_setup = !proving_key_path.exists();
@@ -48,7 +55,7 @@ impl ZkVmProver for PicoProver {
             } else {
                 log::info!("Using existing proving key at {:?}", proving_key_path);
             }
-            
+
             client
                 .prove_evm(
                     stdin_builder,
@@ -69,8 +76,8 @@ impl ZkVmProver for PicoProver {
         // Read and encode proof from proof.data
         let proof_data_path = config.artifacts_path.join("proof.data");
         let proof_bytes = if proof_data_path.exists() {
-            let proof_data = std::fs::read_to_string(&proof_data_path)
-                .context("Failed to read proof.data")?;
+            let proof_data =
+                std::fs::read_to_string(&proof_data_path).context("Failed to read proof.data")?;
 
             // Parse comma-separated hex strings
             let hex_strings: Vec<&str> = proof_data.split(',').collect();
@@ -91,8 +98,7 @@ impl ZkVmProver for PicoProver {
             // Concatenate the 8 proof values (each already 32 bytes)
             for hex_str in proof_values {
                 let hex_str = hex_str.trim().trim_start_matches("0x");
-                let bytes = hex::decode(hex_str)
-                    .context("Failed to decode proof hex string")?;
+                let bytes = hex::decode(hex_str).context("Failed to decode proof hex string")?;
 
                 if bytes.len() != 32 {
                     anyhow::bail!(


### PR DESCRIPTION
## Summary

- reject invalid or missing issuer certificate revocation lists
- bind Intel TCB Info and Quoting Enclave Identity document types to the SGX or TDX quote type
- validate quote headers and nested length fields before consuming attacker-controlled data
- restrict TDX relaunch handling to the Intel-compatible preliminary status allowlist
- return structured errors instead of panics in Rust, WebAssembly, zkVM, and Pico parsing paths

## Validation

- cargo test -p dcap-rs -p automata-dcap-zkvm --lib
- cargo test -p automata-dcap-utils --features wasm --lib
- cargo check -p automata-dcap-utils --features wasm
- RUSTC_BOOTSTRAP=1 cargo check -p automata-dcap-zkvm --features pico
- focused rustfmt check for all 16 changed Rust files
- git diff --check

The full workspace cargo fmt check still reports pre-existing formatting differences in generated and unrelated files. The 16 files changed by this pull request pass the focused formatting check.