### PR TITLE
feat(dcap-rs): allow borrowing verification collateral

### DIFF
--- a/rust-crates/libraries/dcap-rs/src/lib.rs
+++ b/rust-crates/libraries/dcap-rs/src/lib.rs
@@ -193,13 +193,28 @@ pub fn verify_dcap_quote_with_policy(
     quote: Quote,
     policy: &DcapVerificationPolicy,
 ) -> anyhow::Result<VerifiedOutput> {
+    verify_dcap_quote_with_policy_ref(current_time, &collateral, quote, policy)
+}
+
+/// Verifies an SGX or TDX DCAP quote while borrowing the supplied collateral.
+///
+/// This variant allows a verifier to parse signed collateral once and reuse
+/// that immutable value for multiple quotes. Every call still evaluates
+/// certificate and collateral validity against `current_time`.
+#[cfg(feature = "full")]
+pub fn verify_dcap_quote_with_policy_ref(
+    current_time: SystemTime,
+    collateral: &Collateral,
+    quote: Quote,
+    policy: &DcapVerificationPolicy,
+) -> anyhow::Result<VerifiedOutput> {
     // 1. Verify the integrity of the signature chain from the Quote to the Intel-issued PCK
     //    certificate, and that no keys in the chain have been revoked.
     use crate::types::quote::QuoteBody;
-    let tcb_info = verify_integrity(current_time, &collateral, &quote)?;
+    let tcb_info = verify_integrity(current_time, collateral, &quote)?;
 
     // 2. Verify the Quoting Enclave source and all signatures in the Quote.
-    let qe_tcb_status = verify_quote(current_time, &collateral, &quote)?;
+    let qe_tcb_status = verify_quote(current_time, collateral, &quote)?;
 
     reject_invalid_qe_tcb_status(qe_tcb_status)?;
 

--- a/rust-crates/libraries/dcap-rs/tests/tests.rs
+++ b/rust-crates/libraries/dcap-rs/tests/tests.rs
@@ -1,9 +1,8 @@
 mod common;
 
 use common::*;
-use dcap_rs::{
-    DcapVerificationPolicy, types::quote::Quote, verify_dcap_quote, verify_dcap_quote_with_policy,
-};
+use dcap_rs::types::quote::Quote;
+use dcap_rs::{DcapVerificationPolicy, verify_dcap_quote, verify_dcap_quote_with_policy_ref};
 
 #[test]
 fn parse_v3_quote() {
@@ -78,7 +77,7 @@ async fn e2e_v5_quote() {
         allow_service_td: true,
         ..DcapVerificationPolicy::production()
     };
-    let output = verify_dcap_quote_with_policy(test_v5_time(), collateral, quote, &policy)
+    let output = verify_dcap_quote_with_policy_ref(test_v5_time(), &collateral, quote, &policy)
         .expect("certificate chain integrity should succeed when service TDs are allowed");
     println!("{:?}", output);
 }


### PR DESCRIPTION
## Summary

- add verify_dcap_quote_with_policy_ref, which accepts &Collateral
- keep verify_dcap_quote_with_policy source-compatible by delegating to the borrowed entry point
- exercise the borrowed entry point in the version 5 end-to-end test

This lets callers retain one parsed immutable Collateral value while each verification still checks certificates, revocation data, freshness, and validity against the supplied current_time.

## Validation

- cargo check -p dcap-rs --all-targets
- three offline quote parsing tests passed
- five live end-to-end tests reached the configured PCCS but could not obtain collateral for the sample quotes; they failed before the changed verification function ran